### PR TITLE
Non coll results length limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,28 @@
 # Changelog
+[Fireworks](https://github.com/paintparty/fireworks): A color printer for Clojure, ClojureScript, and Babashka. 
+
+
+
+For a list of breaking changes, check [here](#breaking-changes)
+
 
 ## Unreleased
 - 
+
+## 0.2.0
+2024-03-02
+
+### Added
+- Relax length limit for non-coll result display values [#3](https://github.com/paintparty/fireworks/issues/3)
+- Added `:non-coll-result-length-limit` config option 
+- Added `:non-coll-depth-1-length-limit` config option 
+
+### Changed
+- Rename `fireworks.core/p*` -> `fireworks.core/p-data`
+- Rename config option `:mapkey-value-width-limit` -> `:non-coll-mapkey-length-limit`
+- Rename config option `:value-width-limit` -> `:non-coll-length-limit`
+- Update dependency coordinates for `typetag`
+
 
 ## 0.1.1
 2024-03-02

--- a/README.md
+++ b/README.md
@@ -238,24 +238,26 @@ Calling **`fireworks.core/p-data`** in a ClojureScript (browser) context also pr
 For cutting & pasting into your [system-wide config](#system-wide-config), or trying things out at the call site: 
 
 ```Clojure
-{:theme                      "Alabaster Light"
- :mood                       :light            ; :light | :dark
- :line-height                1.45
- :print-level                7
- :value-width-limit          33
- :mapkey-width-limit         20
- :coll-limit                 15
- :evaled-form-coll-limit     7
- :display-namespaces?        true
- :metadata-print-level       7
- :display-metadata?          true
- :metadata-position          :inline           ; :inline | :block
- :enable-rainbow-brackets?   true
- :bracket-contrast           :high             ; :high | :low
- :enable-terminal-truecolor? false
- :enable-terminal-italics?   false
- :custom-printers            nil
- :find                       nil}
+{:theme                         "Alabaster Light"
+ :mood                          :light            ; :light | :dark
+ :line-height                   1.45
+ :print-level                   7
+ :non-coll-length-limit         33
+ :non-coll-mapkey-length-limit  20
+ :non-coll-result-length-limit  444
+ :non-coll-depth-1-length-limit 59
+ :coll-limit                    15
+ :evaled-form-coll-limit        7
+ :display-namespaces?           true
+ :metadata-print-level          7
+ :display-metadata?             true
+ :metadata-position             :inline           ; :inline | :block
+ :enable-rainbow-brackets?      true
+ :bracket-contrast              :high             ; :high | :low
+ :enable-terminal-truecolor?    false
+ :enable-terminal-italics?      false
+ :custom-printers               nil
+ :find                          nil}
 ```
 
 You can configure all of the above options ala-carte. A leading options map arg works with **`fireworks.core/?`**, **`fireworks.core/p`**, and **`fireworks.core/p-data`**.
@@ -342,17 +344,34 @@ Sets the max depth of printing for nested collections.
 <br>
 <br>
 
-**`:value-width-limit`** `33`
+**`:non-coll-length-limit`** `33`
 
-Sets the max length of things like strings, keywords, function names, etc. Values whose length exceeds this will be ellipsized.
+Sets the max length of things like strings, keywords, function names, etc., when they are nested more than 1 level deep inside a data structure. Values whose length exceeds this will be ellipsized.
 
 
 <br>
 <br>
 
-**`:mapkey-width-limit`** `20`
+**`:non-coll-mapkey-length-limit`** `20`
 
 Sets the max length of things like strings, keywords, function names, etc., when they are used as keys in maps. Longer values will be ellipsized.
+
+
+<br>
+<br>
+
+**`:non-coll-result-length-limit`** `444`
+
+Sets the max length of a non-collection value such as a string, keyword, function name, etc. Only applies when the value itself is the result of the evaluation (not nested within a data structure).
+
+
+<br>
+<br>
+
+
+**`:non-coll-depth-1-length-limit`** `69`
+
+Sets the max length of a non-collection value such as a string, keyword, function name, etc. Only applies when the value is nested 1 level deep inside the result, which would be a non-associative collection such as a vector or seq.
 
 
 <br>
@@ -376,7 +395,7 @@ Sets the level of rainbow bracket intensity to `"high"` or `"low"`.  Default val
 
 **`:display-namespaces?`** `true`
 
-Whether or not to print out fully qualified namespaces for functions and classes. Note that even if set to `true`, namespaces may get dropped if the count of fully qualified symbol exceeds the **`:value-width-limit`** or the **`:mapkey-width-limit`** (in the case of map keys).
+Whether or not to print out fully qualified namespaces for functions and classes. Note that even if set to `true`, namespaces may get dropped if the count of fully qualified symbol exceeds the **`:non-coll-length-limit`** or the **`:non-coll-mapkey-length-limit`** (in the case of map keys).
 
 
 <br>
@@ -717,7 +736,7 @@ my-function-with-a-rea...[...]
 
 By default, Fireworks will print the function name with the fully-qualified namespace. This can be disabled by changing the config option `:display-namespaces?` to `false`.
 
-If the fully-qualified name of the function + args vector exceeds the value of `:value-width-limit`, the args will get ellipsized, the namespace will be dropped (if necessary), and the function name will be ellipsized (if necessary).
+If the fully-qualified name of the function + args vector exceeds the value of `:non-coll-length-limit`, the args will get ellipsized, the namespace will be dropped (if necessary), and the function name will be ellipsized (if necessary).
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Add as a dependency to your project:
 [![Clojars Project](https://img.shields.io/clojars/v/io.github.paintparty/fireworks.svg)](https://clojars.org/io.github.paintparty/fireworks)
 
 ```clojure
-[io.github.paintparty/fireworks "0.1.1"]
+[io.github.paintparty/fireworks "0.2.0"]
 ```
 <br>
 

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :source-paths ["src"]
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [expound "0.9.0"]
-                 [io.github.paintparty/typetag "0.3.0"]]
+                 [io.github.paintparty/lasertag "0.3.0"]]
   :repl-options {:init-ns fireworks.core}
   :deploy-repositories [["clojars" {:url           "https://clojars.org/repo"
                                     :sign-releases false}]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.paintparty/fireworks "0.1.1"
+(defproject io.github.paintparty/fireworks "0.2.0"
   :description "Color Pretty Printer for Clojure(Script)"
   :url "https://github.com/paintparty/fireworks"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,6 +1,6 @@
 ;; shadow-cljs configuration
 {:source-paths ["src/" "test/"]
- :dependencies [[io.github.paintparty/typetag "0.3.0"]]
+ :dependencies [[io.github.paintparty/lasertag "0.3.0"]]
  :builds       {:test {:target    :karma
                        :output-to "out/test.js"
                        :ns-regexp "-test$"

--- a/src/fireworks/brackets.cljc
+++ b/src/fireworks/brackets.cljc
@@ -24,7 +24,7 @@
         ["" ""]
         :else
         ;; This should probably be ["" ""]
-        ;; We need more granularity from typetag first
+        ;; We need more granularity from lasertag first
         ;; :list-like? :array-like?
         ["[" "]"]))
 

--- a/src/fireworks/config.cljc
+++ b/src/fireworks/config.cljc
@@ -5,54 +5,54 @@
 
    
 (def options
-  {:theme                     {:spec           ::config/theme
-                               :default        "Alabaster Light"
-                               :updates-theme? true}
-   :mood                      {:spec           ::theme/mood
-                               :default        "light"
-                               :updates-theme? true}
-   :coll-limit                {:spec    ::config/coll-limit
-                               :default 15}
-   :evaled-form-coll-limit    {:spec    ::config/evaled-form-coll-limit
-                               :default 7}
-   :non-coll-length-limit         {:spec    ::config/non-coll-length-limit
-                               :default 33}
-   :mapkey-width-limit        {:spec    ::config/mapkey-width-limit
-                               :default 20}
-   :print-level               {:spec    ::config/print-level
-                               :default 7}
-   :metadata-print-level      {:spec    ::config/metadata-print-level
-                               :default 7}
-   :display-namespaces?       {:spec    ::config/display-namespaces?
-                               :default true}
-   :display-metadata?         {:spec    ::config/display-metadata?
-                               :default true}
-   :metadata-position         {:spec    ::config/metadata-position
-                               :default "inline"}
-   :enable-rainbow-brackets?  {:spec           ::config/enable-rainbow-brackets?
-                               :default        true
-                               :updates-theme? true}
-   :bracket-contrast          {:spec           ::config/bracket-contrast
-                               :default        "high"
-                               :updates-theme? true}
-   :enable-terminal-truecolor? {:spec          ::config/enable-terminal-truecolor?
-                                :default       false
-                                :updates-theme? true}
-   :enable-terminal-italics?  {:spec           ::config/enable-terminal-italics?
-                               :default        false
-                               :updates-theme? true}
-   :line-height               {:spec           ::config/line-height
-                               :default        1.45
-                               :updates-theme? true}
-   :custom-printers           {:spec           ::config/custom-printers
-                               :default        {}}
-   :find                      {:spec     ::config/custom-printers
-                               :default  nil}
+  {:theme                       {:spec           ::config/theme
+                                 :default        "Alabaster Light"
+                                 :updates-theme? true}
+   :mood                        {:spec           ::theme/mood
+                                 :default        "light"
+                                 :updates-theme? true}
+   :coll-limit                  {:spec    ::config/coll-limit
+                                 :default 15}
+   :evaled-form-coll-limit      {:spec    ::config/evaled-form-coll-limit
+                                 :default 7}
+   :non-coll-length-limit       {:spec    ::config/non-coll-length-limit
+                                 :default 33}
+   :non-coll-mapkey-length-limit {:spec    ::config/non-coll-mapkey-length-limit
+                                 :default 20}
+   :print-level                 {:spec    ::config/print-level
+                                 :default 7}
+   :metadata-print-level        {:spec    ::config/metadata-print-level
+                                 :default 7}
+   :display-namespaces?         {:spec    ::config/display-namespaces?
+                                 :default true}
+   :display-metadata?           {:spec    ::config/display-metadata?
+                                 :default true}
+   :metadata-position           {:spec    ::config/metadata-position
+                                 :default "inline"}
+   :enable-rainbow-brackets?    {:spec           ::config/enable-rainbow-brackets?
+                                 :default        true
+                                 :updates-theme? true}
+   :bracket-contrast            {:spec           ::config/bracket-contrast
+                                 :default        "high"
+                                 :updates-theme? true}
+   :enable-terminal-truecolor?  {:spec           ::config/enable-terminal-truecolor?
+                                 :default        false
+                                 :updates-theme? true}
+   :enable-terminal-italics?    {:spec           ::config/enable-terminal-italics?
+                                 :default        false
+                                 :updates-theme? true}
+   :line-height                 {:spec           ::config/line-height
+                                 :default        1.45
+                                 :updates-theme? true}
+   :custom-printers             {:spec    ::config/custom-printers
+                                 :default {}}
+   :find                        {:spec    ::config/custom-printers
+                                 :default nil}
    })
 
 ;; Add new option keys to this list!
 (def option-keys
-  #{:mapkey-width-limit
+  #{:non-coll-mapkey-length-limit
     :line-height
     :enable-terminal-italics?
     :non-coll-length-limit

--- a/src/fireworks/config.cljc
+++ b/src/fireworks/config.cljc
@@ -5,59 +5,62 @@
 
    
 (def options
-  {:theme                        {:spec           ::config/theme
-                                  :default        "Alabaster Light"
-                                  :updates-theme? true}
-   :mood                         {:spec           ::theme/mood
-                                  :default        "light"
-                                  :updates-theme? true}
-   :coll-limit                   {:spec    ::config/coll-limit
-                                  :default 15}
-   :evaled-form-coll-limit       {:spec    ::config/evaled-form-coll-limit
-                                  :default 7}
-   :non-coll-result-length-limit {:spec    ::config/non-coll-result-length-limit
-                                  :default 444}
-   :non-coll-length-limit        {:spec    ::config/non-coll-length-limit
-                                  :default 33}
-   :non-coll-mapkey-length-limit {:spec    ::config/non-coll-mapkey-length-limit
-                                  :default 20}
-   :print-level                  {:spec    ::config/print-level
-                                  :default 7}
-   :metadata-print-level         {:spec    ::config/metadata-print-level
-                                  :default 7}
-   :display-namespaces?          {:spec    ::config/display-namespaces?
-                                  :default true}
-   :display-metadata?            {:spec    ::config/display-metadata?
-                                  :default true}
-   :metadata-position            {:spec    ::config/metadata-position
-                                  :default "inline"}
-   :enable-rainbow-brackets?     {:spec           ::config/enable-rainbow-brackets?
-                                  :default        true
-                                  :updates-theme? true}
-   :bracket-contrast             {:spec           ::config/bracket-contrast
-                                  :default        "high"
-                                  :updates-theme? true}
-   :enable-terminal-truecolor?   {:spec           ::config/enable-terminal-truecolor?
-                                  :default        false
-                                  :updates-theme? true}
-   :enable-terminal-italics?     {:spec           ::config/enable-terminal-italics?
-                                  :default        false
-                                  :updates-theme? true}
-   :line-height                  {:spec           ::config/line-height
-                                  :default        1.45
-                                  :updates-theme? true}
-   :custom-printers              {:spec    ::config/custom-printers
-                                  :default {}}
-   :find                         {:spec    ::config/custom-printers
-                                  :default nil}
+  {:theme                         {:spec           ::config/theme
+                                   :default        "Alabaster Light"
+                                   :updates-theme? true}
+   :mood                          {:spec           ::theme/mood
+                                   :default        "light"
+                                   :updates-theme? true}
+   :coll-limit                    {:spec    ::config/coll-limit
+                                   :default 15}
+   :evaled-form-coll-limit        {:spec    ::config/evaled-form-coll-limit
+                                   :default 7}
+   :non-coll-result-length-limit  {:spec    ::config/non-coll-result-length-limit
+                                   :default 444}
+   :non-coll-depth-1-length-limit {:spec    ::config/non-coll-depth-1-length-limit
+                                   :default 69}
+   :non-coll-length-limit         {:spec    ::config/non-coll-length-limit
+                                   :default 33}
+   :non-coll-mapkey-length-limit  {:spec    ::config/non-coll-mapkey-length-limit
+                                   :default 20}
+   :print-level                   {:spec    ::config/print-level
+                                   :default 7}
+   :metadata-print-level          {:spec    ::config/metadata-print-level
+                                   :default 7}
+   :display-namespaces?           {:spec    ::config/display-namespaces?
+                                   :default true}
+   :display-metadata?             {:spec    ::config/display-metadata?
+                                   :default true}
+   :metadata-position             {:spec    ::config/metadata-position
+                                   :default "inline"}
+   :enable-rainbow-brackets?      {:spec           ::config/enable-rainbow-brackets?
+                                   :default        true
+                                   :updates-theme? true}
+   :bracket-contrast              {:spec           ::config/bracket-contrast
+                                   :default        "high"
+                                   :updates-theme? true}
+   :enable-terminal-truecolor?    {:spec           ::config/enable-terminal-truecolor?
+                                   :default        false
+                                   :updates-theme? true}
+   :enable-terminal-italics?      {:spec           ::config/enable-terminal-italics?
+                                   :default        false
+                                   :updates-theme? true}
+   :line-height                   {:spec           ::config/line-height
+                                   :default        1.45
+                                   :updates-theme? true}
+   :custom-printers               {:spec    ::config/custom-printers
+                                   :default {}}
+   :find                          {:spec    ::config/custom-printers
+                                   :default nil}
    })
 
 ;; Add new option keys to this list!
 (def option-keys
-  #{:non-coll-mapkey-length-limit
-    :line-height
+  #{:line-height
     :enable-terminal-italics?
     :non-coll-result-length-limit
+    :non-coll-depth-1-length-limit
+    :non-coll-mapkey-length-limit
     :non-coll-length-limit
     :display-namespaces?
     :enable-rainbow-brackets?

--- a/src/fireworks/config.cljc
+++ b/src/fireworks/config.cljc
@@ -15,7 +15,7 @@
                                :default 15}
    :evaled-form-coll-limit    {:spec    ::config/evaled-form-coll-limit
                                :default 7}
-   :value-width-limit         {:spec    ::config/value-width-limit
+   :non-coll-length-limit         {:spec    ::config/non-coll-length-limit
                                :default 33}
    :mapkey-width-limit        {:spec    ::config/mapkey-width-limit
                                :default 20}
@@ -55,7 +55,7 @@
   #{:mapkey-width-limit
     :line-height
     :enable-terminal-italics?
-    :value-width-limit
+    :non-coll-length-limit
     :display-namespaces?
     :enable-rainbow-brackets?
     :enable-terminal-truecolor?

--- a/src/fireworks/config.cljc
+++ b/src/fireworks/config.cljc
@@ -48,10 +48,7 @@
                                :default        {}}
    :find                      {:spec     ::config/custom-printers
                                :default  nil}
-
-   :display-all-built-in-js-objects-uniformly?
-   {:spec    ::config/display-all-built-in-js-objects-uniformly?
-    :default false}})
+   })
 
 ;; Add new option keys to this list!
 (def option-keys
@@ -68,7 +65,6 @@
     :mood
     :coll-limit
     :evaled-form-coll-limit
-    :display-all-built-in-js-objects-uniformly?
     :display-metadata?
     :metadata-position
     :bracket-contrast

--- a/src/fireworks/config.cljc
+++ b/src/fireworks/config.cljc
@@ -5,49 +5,51 @@
 
    
 (def options
-  {:theme                       {:spec           ::config/theme
-                                 :default        "Alabaster Light"
-                                 :updates-theme? true}
-   :mood                        {:spec           ::theme/mood
-                                 :default        "light"
-                                 :updates-theme? true}
-   :coll-limit                  {:spec    ::config/coll-limit
-                                 :default 15}
-   :evaled-form-coll-limit      {:spec    ::config/evaled-form-coll-limit
-                                 :default 7}
-   :non-coll-length-limit       {:spec    ::config/non-coll-length-limit
-                                 :default 33}
+  {:theme                        {:spec           ::config/theme
+                                  :default        "Alabaster Light"
+                                  :updates-theme? true}
+   :mood                         {:spec           ::theme/mood
+                                  :default        "light"
+                                  :updates-theme? true}
+   :coll-limit                   {:spec    ::config/coll-limit
+                                  :default 15}
+   :evaled-form-coll-limit       {:spec    ::config/evaled-form-coll-limit
+                                  :default 7}
+   :non-coll-result-length-limit {:spec    ::config/non-coll-result-length-limit
+                                  :default 444}
+   :non-coll-length-limit        {:spec    ::config/non-coll-length-limit
+                                  :default 33}
    :non-coll-mapkey-length-limit {:spec    ::config/non-coll-mapkey-length-limit
-                                 :default 20}
-   :print-level                 {:spec    ::config/print-level
-                                 :default 7}
-   :metadata-print-level        {:spec    ::config/metadata-print-level
-                                 :default 7}
-   :display-namespaces?         {:spec    ::config/display-namespaces?
-                                 :default true}
-   :display-metadata?           {:spec    ::config/display-metadata?
-                                 :default true}
-   :metadata-position           {:spec    ::config/metadata-position
-                                 :default "inline"}
-   :enable-rainbow-brackets?    {:spec           ::config/enable-rainbow-brackets?
-                                 :default        true
-                                 :updates-theme? true}
-   :bracket-contrast            {:spec           ::config/bracket-contrast
-                                 :default        "high"
-                                 :updates-theme? true}
-   :enable-terminal-truecolor?  {:spec           ::config/enable-terminal-truecolor?
-                                 :default        false
-                                 :updates-theme? true}
-   :enable-terminal-italics?    {:spec           ::config/enable-terminal-italics?
-                                 :default        false
-                                 :updates-theme? true}
-   :line-height                 {:spec           ::config/line-height
-                                 :default        1.45
-                                 :updates-theme? true}
-   :custom-printers             {:spec    ::config/custom-printers
-                                 :default {}}
-   :find                        {:spec    ::config/custom-printers
-                                 :default nil}
+                                  :default 20}
+   :print-level                  {:spec    ::config/print-level
+                                  :default 7}
+   :metadata-print-level         {:spec    ::config/metadata-print-level
+                                  :default 7}
+   :display-namespaces?          {:spec    ::config/display-namespaces?
+                                  :default true}
+   :display-metadata?            {:spec    ::config/display-metadata?
+                                  :default true}
+   :metadata-position            {:spec    ::config/metadata-position
+                                  :default "inline"}
+   :enable-rainbow-brackets?     {:spec           ::config/enable-rainbow-brackets?
+                                  :default        true
+                                  :updates-theme? true}
+   :bracket-contrast             {:spec           ::config/bracket-contrast
+                                  :default        "high"
+                                  :updates-theme? true}
+   :enable-terminal-truecolor?   {:spec           ::config/enable-terminal-truecolor?
+                                  :default        false
+                                  :updates-theme? true}
+   :enable-terminal-italics?     {:spec           ::config/enable-terminal-italics?
+                                  :default        false
+                                  :updates-theme? true}
+   :line-height                  {:spec           ::config/line-height
+                                  :default        1.45
+                                  :updates-theme? true}
+   :custom-printers              {:spec    ::config/custom-printers
+                                  :default {}}
+   :find                         {:spec    ::config/custom-printers
+                                  :default nil}
    })
 
 ;; Add new option keys to this list!
@@ -55,6 +57,7 @@
   #{:non-coll-mapkey-length-limit
     :line-height
     :enable-terminal-italics?
+    :non-coll-result-length-limit
     :non-coll-length-limit
     :display-namespaces?
     :enable-rainbow-brackets?

--- a/src/fireworks/core.cljc
+++ b/src/fireworks/core.cljc
@@ -175,7 +175,7 @@
   [source
    {:keys [form-meta
            qf
-           p*?
+           p-data?
            label
            ns-str]
     :as   opts}] 
@@ -218,7 +218,7 @@
                               (or label form)
                               arrow+linebreaks
                               fmt)]
-    (if p*?
+    (if p-data?
       (merge
        {:ns-str        ns-str
         :file-info-str file-info*
@@ -374,7 +374,7 @@
                                        :clj Exception)
                                     e
                                (messaging/->FireworksThrowable e)))]
-      (if (:p*? opts) 
+      (if (:p-data? opts) 
         printing-opts
         (do 
           (messaging/print-formatted printing-opts
@@ -387,12 +387,12 @@
 
 (defn- cfg-opts
   "Helper for shaping opts arg to be passed to fireworks.core/_p"
-  [{:keys [p*? a form-meta]}]
+  [{:keys [p-data? a form-meta]}]
   (let [cfg-opts  (when (map? a) a)
         label     (if cfg-opts (:label cfg-opts) a)
         cfg-opts  (merge (dissoc (or cfg-opts {}) :label)
                          {:ns-str    (some-> *ns* ns-name str)
-                          :p*?       p*?
+                          :p-data?       p-data?
                           :label     label
                           :form-meta form-meta
                           :user-opts cfg-opts})]
@@ -470,7 +470,7 @@
                            ~x)))))
 
 
-(defmacro p*
+(defmacro p-data
   "Formats the namespace info, then the form (or user-supplied label),
    and then the value. The form (or optional label) and value are
    formatted with fireworks.core/p.
@@ -501,7 +501,7 @@
 
   ([x]
    (let [{:keys [cfg-opts
-                 defd]}   (helper2 {:p*?       true
+                 defd]}   (helper2 {:p-data?       true
                                     :x         x
                                     :form-meta (meta &form)})]
      (if defd
@@ -517,7 +517,7 @@
 
   ([a x]
    (let [{:keys [cfg-opts
-                 defd]}   (helper2 {:p*?       true
+                 defd]}   (helper2 {:p-data?       true
                                     :a         a
                                     :x         x
                                     :form-meta (meta &form)})]

--- a/src/fireworks/core.cljc
+++ b/src/fireworks/core.cljc
@@ -56,7 +56,7 @@
 
 
    In this example, the user-supplied label + newline is shorter
-   than the value-width-limit(from config), so no newline.
+   than the non-coll-length-limit(from config), so no newline.
 
    (? \"my form\" [1 2 3])
 
@@ -66,7 +66,7 @@
 
 
    In this example, the user-supplied label + newline is
-   longer than the value-width-limit(from config), so newline.
+   longer than the non-coll-length-limit(from config), so newline.
 
    (? \"my form\" [\"one\" \"two\" \"three\" \"four\" \"aadfasdfasd\"])
      
@@ -77,7 +77,7 @@
    
 
    In this example, the form-to-be-evaled + newline is shorter
-   than the value-width-limit (from config), so no newline.
+   than the non-coll-length-limit (from config), so no newline.
 
    (? (+ 2 3))
 
@@ -86,8 +86,8 @@
    
 
    In this example, the form-to-be-evaled + newline + arrow + result is 
-   longer than the value-width-limit (from config), but the arrow + result
-   is shorter than value-width-limit, so newline + arrow + value.
+   longer than the non-coll-length-limit (from config), but the arrow + result
+   is shorter than non-coll-length-limit, so newline + arrow + value.
 
    (? (range 10))
 
@@ -97,8 +97,8 @@
    
     
    In this example, the form-to-be-evaled + newline + arrow + result is 
-   longer than the value-width-limit (from config), and the arrow + result is
-   also longer than value-width-limit, so newline + arrow + newline + value.
+   longer than the non-coll-length-limit (from config), and the arrow + result is
+   also longer than non-coll-length-limit, so newline + arrow + newline + value.
    (? (range 20))
 
    `my.namespace:12:1
@@ -137,23 +137,23 @@
           (+  (or comment-or-form+arrow-len 0) (or len 0))
 
           wl
-          (:value-width-limit @state/config)
+          (:non-coll-length-limit @state/config)
 
-          comment-or-form+arrow+result-is-longer-than-value-width-limit?
+          comment-or-form+arrow+result-is-longer-than-non-coll-length-limit?
           (> comment-or-form+arrow+result-len wl)
 
-          result-is-longer-than-value-width-limit?
-          (> len (:value-width-limit @state/config))
+          result-is-longer-than-non-coll-length-limit?
+          (> len (:non-coll-length-limit @state/config))
           
           formatted-is-multi-line?
           (boolean (re-find #"\n" fmt))]
 
-      (if comment-or-form+arrow+result-is-longer-than-value-width-limit?
+      (if comment-or-form+arrow+result-is-longer-than-non-coll-length-limit?
         (if form
           (str "\n"
                tagged-arrow 
                (if (or formatted-is-multi-line?
-                       result-is-longer-than-value-width-limit?)
+                       result-is-longer-than-non-coll-length-limit?)
                  "\n"
                  " "))
           "\n")
@@ -556,7 +556,7 @@
 
 (defn- ?>* 
   [label ret]
-  [(< (:value-width-limit @state/config)
+  [(< (:non-coll-length-limit @state/config)
       (+ (or (-> label str count) 0)
          (or (-> ret str count) 0)))
    ;; should this be pprint?

--- a/src/fireworks/ellipsize.cljc
+++ b/src/fireworks/ellipsize.cljc
@@ -207,7 +207,8 @@
   [x 
    {:keys [t limit key? badge inline-badge? atom? sev? depth]
     :as   m}]
-  (let [{:keys [non-coll-result-length-limit
+  (let [{:keys [non-coll-depth-1-length-limit
+                non-coll-result-length-limit
                 non-coll-mapkey-length-limit
                 non-coll-length-limit]}
         @state/config
@@ -219,7 +220,7 @@
                                :level-1-sev)]
           (case level-k
             :level-0-sev non-coll-result-length-limit
-            :level-1-sev 69)
+            :level-1-sev non-coll-depth-1-length-limit)
           (max (if key?
                  non-coll-mapkey-length-limit
                  non-coll-length-limit)

--- a/src/fireworks/ellipsize.cljc
+++ b/src/fireworks/ellipsize.cljc
@@ -201,13 +201,13 @@
 (defn ellipsized
   "Ellipsizes longer-than acceptable self-evaluating values such as strings,
    regexes, keywords, #insts, fns, etc. Truncation is based on the following:
-   - :mapkey-width-limit or :non-coll-length-limit values from config
+   - :non-coll-mapkey-length-limit or :non-coll-length-limit values from config
    - Optional inline badge length e.g `#js`
    - Optional atom encapsulation e.g. `Atom<42>`"
   [x 
    {:keys [t limit key? badge inline-badge? atom? sev? depth]
     :as   m}]
-  (let [{:keys [mapkey-width-limit
+  (let [{:keys [non-coll-mapkey-length-limit
                 non-coll-length-limit]}
         @state/config
 
@@ -220,7 +220,7 @@
             :level-0-sev 500
             :level-1-sev 69)
           (max (if key?
-                 mapkey-width-limit
+                 non-coll-mapkey-length-limit
                  non-coll-length-limit)
                (or limit 0)))]
     (if (:ellipsized-char-count m)

--- a/src/fireworks/ellipsize.cljc
+++ b/src/fireworks/ellipsize.cljc
@@ -56,7 +56,7 @@
     :as   m}]
   (let [;; Create `budge-diff` partial, which will be used to calculate
         ;; the difference between the length of the fn name (at a given
-        ;; stage of shortening) and the (:value-width-limit @state/config).
+        ;; stage of shortening) and the (:non-coll-length-limit @state/config).
         atom-wrap-count (or (when atom? defs/atom-wrap-count) 0)
         budge-diff      (partial budge-diff limit atom-wrap-count)
         
@@ -120,7 +120,7 @@
 
 
         ;; Finally, calculate the final ellipsized-char-count. This count
-        ;; should never exceed the :value-width-limit, or the
+        ;; should never exceed the :non-coll-length-limit, or the
         ;; :map-key-width-limit, from @state/config.
         ecc             (+ (ellipsized-char-count badge
                                                   (str fn-display-name)
@@ -201,14 +201,14 @@
 (defn ellipsized
   "Ellipsizes longer-than acceptable self-evaluating values such as strings,
    regexes, keywords, #insts, fns, etc. Truncation is based on the following:
-   - :mapkey-width-limit or :value-width-limit values from config
+   - :mapkey-width-limit or :non-coll-length-limit values from config
    - Optional inline badge length e.g `#js`
    - Optional atom encapsulation e.g. `Atom<42>`"
   [x 
    {:keys [t limit key? badge inline-badge? atom? sev? depth]
     :as   m}]
   (let [{:keys [mapkey-width-limit
-                value-width-limit]}
+                non-coll-length-limit]}
         @state/config
 
         limit
@@ -221,7 +221,7 @@
             :level-1-sev 69)
           (max (if key?
                  mapkey-width-limit
-                 value-width-limit)
+                 non-coll-length-limit)
                (or limit 0)))]
     (if (:ellipsized-char-count m)
       x

--- a/src/fireworks/ellipsize.cljc
+++ b/src/fireworks/ellipsize.cljc
@@ -2,7 +2,7 @@
 (:require
    [clojure.string :as string]
    [fireworks.defs :as defs]
-   [fireworks.pp :refer [?pp]]
+  ;;  [fireworks.pp :refer [?pp]]
    [fireworks.state :as state]
    #?(:cljs [fireworks.macros :refer-macros [keyed]])
    #?(:clj [fireworks.macros :refer [keyed]])))

--- a/src/fireworks/ellipsize.cljc
+++ b/src/fireworks/ellipsize.cljc
@@ -205,18 +205,20 @@
    - Optional inline badge length e.g `#js`
    - Optional atom encapsulation e.g. `Atom<42>`"
   [x 
-   {:keys [t limit key? badge inline-badge? atom?]
+   {:keys [t limit key? badge inline-badge? atom? sev? depth]
     :as   m}]
   (let [{:keys [mapkey-width-limit
                 value-width-limit]}
         @state/config
 
         limit
-        (if @state/top-level-value-is-sev?
-          ;; TODO - make this a config value with upper-bound
-          ;; maybe call it top-level-scalar-value-length-limit
-          ;; maybe change `width-limit*` to length-limit ?
-          500
+        (if-let [level-k (cond @state/top-level-value-is-sev?
+                               :level-0-sev
+                               (and sev? (< depth 2))
+                               :level-1-sev)]
+          (case level-k
+            :level-0-sev 500
+            :level-1-sev 69)
           (max (if key?
                  mapkey-width-limit
                  value-width-limit)

--- a/src/fireworks/ellipsize.cljc
+++ b/src/fireworks/ellipsize.cljc
@@ -207,7 +207,8 @@
   [x 
    {:keys [t limit key? badge inline-badge? atom? sev? depth]
     :as   m}]
-  (let [{:keys [non-coll-mapkey-length-limit
+  (let [{:keys [non-coll-result-length-limit
+                non-coll-mapkey-length-limit
                 non-coll-length-limit]}
         @state/config
 
@@ -217,7 +218,7 @@
                                (and sev? (< depth 2))
                                :level-1-sev)]
           (case level-k
-            :level-0-sev 500
+            :level-0-sev non-coll-result-length-limit
             :level-1-sev 69)
           (max (if key?
                  non-coll-mapkey-length-limit

--- a/src/fireworks/ellipsize.cljc
+++ b/src/fireworks/ellipsize.cljc
@@ -22,10 +22,10 @@
 (defn- fn-args*
   [fn-args]
   (if (contains? 
-       #{:typetag/unknown-function-signature-on-js-built-in-method
-         :typetag/unknown-function-signature-on-clj-function
-         :typetag/unknown-function-signature-on-java-class
-         :typetag/multimethod}
+       #{:lasertag/unknown-function-signature-on-js-built-in-method
+         :lasertag/unknown-function-signature-on-clj-function
+         :lasertag/unknown-function-signature-on-java-class
+         :lasertag/multimethod}
        fn-args)
     defs/mysterious-fn-args
     fn-args))

--- a/src/fireworks/macros.clj
+++ b/src/fireworks/macros.clj
@@ -1,11 +1,9 @@
 (ns fireworks.macros
  (:require  
-  [clojure.string :as string]
   [fireworks.messaging :as messaging]
   [fireworks.specs.config :as config]
   [fireworks.specs.theme :as theme]
   [fireworks.basethemes :as basethemes]
-  [fireworks.pp :refer [?pp]]
   [clojure.edn :as edn]
   [clojure.spec.alpha :as s]))
 

--- a/src/fireworks/messaging.cljc
+++ b/src/fireworks/messaging.cljc
@@ -201,7 +201,7 @@
             mini-st     (->> st (take 10) (map StackTraceElement->vec))
             indexes     (keep-indexed
                          (fn [i [f]]
-                           (when (re-find #"^fireworks\.|^typetag\."
+                           (when (re-find #"^fireworks\.|^lasertag\."
                                           (str f)) 
                              i))
                          mini-st)

--- a/src/fireworks/printers.cljc
+++ b/src/fireworks/printers.cljc
@@ -1,8 +1,6 @@
 (ns fireworks.printers
   (:require
    [clojure.string :as string]
-   [fireworks.profile :as profile]
-   [fireworks.pp :refer [?pp]]
    [fireworks.truncate :as truncate]
    [fireworks.state :as state]
    [clojure.set :as set]

--- a/src/fireworks/printers.cljc
+++ b/src/fireworks/printers.cljc
@@ -4,7 +4,7 @@
    [fireworks.truncate :as truncate]
    [fireworks.state :as state]
    [clojure.set :as set]
-   [typetag.core :as typetag]))
+   [lasertag.core :as lasertag]))
 
 #?(:cljs
    (do 
@@ -119,7 +119,7 @@
             t            :t
             all-tags :all-tags}
            (or (some-> x meta :fw/truncated)
-               (let [m (typetag/tag-map x 
+               (let [m (lasertag/tag-map x 
                                         {:function-info?           false
                                          :js-built-in-object-info? false})]
                  (set/rename-keys m {:tag :t})))

--- a/src/fireworks/profile.cljc
+++ b/src/fireworks/profile.cljc
@@ -5,13 +5,13 @@
    [fireworks.ellipsize :as ellipsize]
    [fireworks.state :as state]
    [fireworks.pp :as pp :refer [?pp]]
-   [typetag.core :as typetag]
+   [lasertag.core :as lasertag]
    #?(:cljs [fireworks.macros :refer-macros [keyed]])
    #?(:clj [fireworks.macros :refer [keyed]])
    [clojure.string :as string]))
 
 
-(def badges-by-typetag
+(def badges-by-lasertag
   {:js/Set         "js/Set"
    :js/Promise     "js/Promise"
    :js/Iterator    defs/js-literal-badge
@@ -43,11 +43,11 @@
                 (and (not= t :js/Object)
                      (or (contains? all-tags :js/map-like-object)
                          (contains? all-tags :js/TypedArray)))
-                (or (t badges-by-typetag)
+                (or (t badges-by-lasertag)
                     (subs (str t) 1))
 
                 :else
-                (t badges-by-typetag)))
+                (t badges-by-lasertag)))
         b #?(:cljs b
              :clj (if (= t :defmulti) "Multimethod" b))]
 
@@ -221,7 +221,7 @@
             :as fw-truncated-meta}  (or (some-> x meta :fw/truncated)
                                         ;; only for map-entries (kvs)
                                         (-> x
-                                            typetag/tag-map
+                                            lasertag/tag-map
                                             (set/rename-keys {:tag :t})))
            ret   (merge 
                   fw-truncated-meta

--- a/src/fireworks/serialize.cljc
+++ b/src/fireworks/serialize.cljc
@@ -148,7 +148,7 @@
             (boolean 
              (when (< 1 coll-count)
                (or single-column-map-layout?
-                   (< (:value-width-limit @state/config)
+                   (< (:non-coll-length-limit @state/config)
                       (or str-len-with-badge 0))))))
 
         ;; This is where indenting for multi-line collections is determined

--- a/src/fireworks/sev.cljc
+++ b/src/fireworks/sev.cljc
@@ -1,7 +1,6 @@
 (ns ^:dev/always fireworks.sev
   (:require
    [fireworks.defs :as defs]
-   [fireworks.pp :refer [?pp]]
    [fireworks.state :as state]
    [fireworks.tag :as tag :refer [tagged tag! tag-reset!]]
    #?(:cljs [fireworks.macros :refer-macros [keyed]])

--- a/src/fireworks/specs/config.cljc
+++ b/src/fireworks/specs/config.cljc
@@ -43,6 +43,9 @@
 (s/def ::evaled-form-coll-limit
   ::fw-coll-limit)
 
+(s/def ::non-coll-result-length-limit
+  (s/and int? #(<= 10 % 1000)))
+
 (s/def ::non-coll-length-limit
   (s/and int? #(<= 10 % 80)))
 
@@ -105,6 +108,7 @@
          (s/keys :opt-un [::non-coll-mapkey-length-limit 
                           ::line-height 
                           ::enable-terminal-italics? 
+                          ::non-coll-result-length-limit 
                           ::non-coll-length-limit 
                           ::display-namespaces? 
                           ::enable-rainbow-brackets? 

--- a/src/fireworks/specs/config.cljc
+++ b/src/fireworks/specs/config.cljc
@@ -64,9 +64,6 @@
 (s/def ::metadata-position
   #{:inline :block "inline" "block"})
 
-(s/def ::display-all-built-in-js-objects-uniformly?
-  boolean?)
-
 (s/def ::enable-rainbow-brackets?
   boolean?)
 
@@ -118,7 +115,6 @@
                           ::mood 
                           ::coll-limit 
                           ::evaled-form-coll-limit 
-                          ::display-all-built-in-js-objects-uniformly? 
                           ::display-metadata? 
                           ::metadata-position 
                           ::bracket-contrast

--- a/src/fireworks/specs/config.cljc
+++ b/src/fireworks/specs/config.cljc
@@ -46,7 +46,7 @@
 (s/def ::non-coll-length-limit
   (s/and int? #(<= 10 % 80)))
 
-(s/def ::mapkey-width-limit
+(s/def ::non-coll-mapkey-length-limit
   (s/and int? #(<= 5 % 80)))
 
 (s/def ::print-level
@@ -102,7 +102,7 @@
 
 (s/def ::fireworks-user-config
   (s/and map?
-         (s/keys :opt-un [::mapkey-width-limit 
+         (s/keys :opt-un [::non-coll-mapkey-length-limit 
                           ::line-height 
                           ::enable-terminal-italics? 
                           ::non-coll-length-limit 

--- a/src/fireworks/specs/config.cljc
+++ b/src/fireworks/specs/config.cljc
@@ -43,8 +43,14 @@
 (s/def ::evaled-form-coll-limit
   ::fw-coll-limit)
 
-(s/def ::non-coll-result-length-limit
+(s/def ::non-coll-extended-length-limit
   (s/and int? #(<= 10 % 1000)))
+
+(s/def ::non-coll-result-length-limit
+  ::non-coll-extended-length-limit)
+
+(s/def ::non-coll-depth-1-length-limit
+  ::non-coll-extended-length-limit)
 
 (s/def ::non-coll-length-limit
   (s/and int? #(<= 10 % 80)))
@@ -105,10 +111,11 @@
 
 (s/def ::fireworks-user-config
   (s/and map?
-         (s/keys :opt-un [::non-coll-mapkey-length-limit 
-                          ::line-height 
+         (s/keys :opt-un [::line-height 
                           ::enable-terminal-italics? 
-                          ::non-coll-result-length-limit 
+                          ::non-coll-result-length-limit
+                          ::non-coll-depth-1-length-limit
+                          ::non-coll-mapkey-length-limit 
                           ::non-coll-length-limit 
                           ::display-namespaces? 
                           ::enable-rainbow-brackets? 

--- a/src/fireworks/specs/config.cljc
+++ b/src/fireworks/specs/config.cljc
@@ -43,7 +43,7 @@
 (s/def ::evaled-form-coll-limit
   ::fw-coll-limit)
 
-(s/def ::value-width-limit
+(s/def ::non-coll-length-limit
   (s/and int? #(<= 10 % 80)))
 
 (s/def ::mapkey-width-limit
@@ -105,7 +105,7 @@
          (s/keys :opt-un [::mapkey-width-limit 
                           ::line-height 
                           ::enable-terminal-italics? 
-                          ::value-width-limit 
+                          ::non-coll-length-limit 
                           ::display-namespaces? 
                           ::enable-rainbow-brackets? 
                           ::enable-terminal-truecolor? 

--- a/src/fireworks/tag.cljc
+++ b/src/fireworks/tag.cljc
@@ -166,7 +166,7 @@
   (let [block?              (contains? #{"block" :block} metadata-position)
         optional-caret-char (when block? "^") 
         stringified         (str optional-caret-char user-meta)
-        multi-line?         (< (:value-width-limit @state/config)
+        multi-line?         (< (:non-coll-length-limit @state/config)
                                (count stringified))
         inline-offset       (when-not block?
                               (spaces defs/metadata-position-inline-offset))

--- a/src/fireworks/tag.cljc
+++ b/src/fireworks/tag.cljc
@@ -2,7 +2,6 @@
   (:require
    [clojure.string :as string]
    [fireworks.defs :as defs]
-   [fireworks.pp :refer [?pp]]
    [fireworks.state :as state]
    [fireworks.util :refer [spaces]]
    #?(:cljs [fireworks.macros :refer-macros [keyed]])
@@ -148,12 +147,6 @@
                                      (when inline-offset (metamap-offset-background l))
                                      (tagged l {:theme-token theme-token}))))
                                w-indent*)]
-
-    ;; (?pp [indent str-len-with-badge])
-    ;; (?pp lines)
-    ;; (?pp w-indent*)
-    ;; (?pp w-indent)
-
     (string/join w-indent)))
 
 

--- a/src/fireworks/truncate.cljc
+++ b/src/fireworks/truncate.cljc
@@ -5,9 +5,9 @@
    [fireworks.state :as state]
    [fireworks.serialize :refer [seq->sorted-set seq->sorted-map]]
    [fireworks.util :as util]
-   [typetag.core :as typetag]
+   [lasertag.core :as lasertag]
    #?(:cljs [fireworks.macros :refer-macros [keyed]])
-   #?(:cljs [typetag.cljs-interop :refer [js-built-in-objects-by-object-map]])
+   #?(:cljs [lasertag.cljs-interop :refer [js-built-in-objects-by-object-map]])
    #?(:clj [fireworks.macros :refer [keyed]])))
 
 (defn pre-truncated? [x]
@@ -298,16 +298,16 @@
   [{:keys [n
            x
            t
-           typetag-map
+           lasertag-map
            kv?
            atom?
            val-meta
            evaled-form?] 
     :as opts}]
-  (let [map-like?         (:map-like? typetag-map)
-        set-like?         (or (= t :js/Set) (:set-like? typetag-map))
-        og-coll-size      (:coll-size typetag-map)
-        all-tags          (:all-tags typetag-map)
+  (let [map-like?         (:map-like? lasertag-map)
+        set-like?         (or (= t :js/Set) (:set-like? lasertag-map))
+        og-coll-size      (:coll-size lasertag-map)
+        all-tags          (:all-tags lasertag-map)
         js-map-like?      (contains? all-tags :js/map-like-object)
         js-typed-array?   (contains? all-tags :js/TypedArray)
         dom-element-node? (contains? all-tags :dom-element-node)
@@ -343,7 +343,7 @@
                                 _             (when (= t :js/Set) str-len)
                                 meta-map      (when-not kv?
                                                 (merge
-                                                 typetag-map
+                                                 lasertag-map
                                                  (keyed [str-len
                                                          num-dropped
                                                          map-like?
@@ -389,10 +389,10 @@
          (map-entry? x)
 
          {:keys [coll-type? t]
-          :as   typetag-map}     
+          :as   lasertag-map}     
          (when-not kv?
            (-> x
-               (typetag/tag-map 
+               (lasertag/tag-map 
                 (when 
                  ;; TODO - When refactoring to attach metadata to
                  ;; non-colls in this truncation fn ...
@@ -409,12 +409,12 @@
      (if (or coll-type? kv?)
 
        ;; Potenitally shorten coll and attach meta
-       (new-coll (merge (keyed [n x kv? t typetag-map atom? val-meta]) opts))
+       (new-coll (merge (keyed [n x kv? t lasertag-map atom? val-meta]) opts))
 
        ;; Optionally symbolize non-colls and attach meta
        (if (pre-truncated? x)
          x
-         (let [meta-map (assoc typetag-map 
+         (let [meta-map (assoc lasertag-map 
                                :x x
                                :og-x og-x
                                :atom? atom?

--- a/src/fireworks/truncate.cljc
+++ b/src/fireworks/truncate.cljc
@@ -418,7 +418,8 @@
                                :x x
                                :og-x og-x
                                :atom? atom?
-                               :sev? true)
+                               :sev? true
+                               :depth n)
                ret*     (if (util/carries-meta? x) 
                           x
                           (symbol (str x)))

--- a/src/fireworks/truncate.cljc
+++ b/src/fireworks/truncate.cljc
@@ -240,11 +240,11 @@
 
   [{:keys [coll num-dropped map-like? set-like? new-coll-size]}]
 
-  ;; The `(:value-width-limit @state/config)` value the `or` branch of the
+  ;; The `(:non-coll-length-limit @state/config)` value the `or` branch of the
   ;; str-len binding is temp placeholder, in case an exception is caught from
   ;; trying to stringify a coll that contains something like a js/TypedArray.
   (let [str-len (or (some-> coll stringified-coll count)
-                    (:value-width-limit @state/config))
+                    (:non-coll-length-limit @state/config))
         ret*    (cond 
                   ;; We are adding +1 for leading `#` char on
                   ;; set-like interop objects such as js/Set

--- a/test/fireworks/core_test.cljc
+++ b/test/fireworks/core_test.cljc
@@ -65,8 +65,8 @@
          (is (= 
               (let [ret (p* {:label             "my-label-from-opts"
                              :theme             theme
-                             :value-width-limit (-> fireworks.config/options
-                                                    :value-width-limit
+                             :non-coll-length-limit (-> fireworks.config/options
+                                                    :non-coll-length-limit
                                                     :default)}
                             "foo")]
                 #_(pp/pprint ret) ret)
@@ -96,8 +96,8 @@
                                           :bracket-contrast           "high"
                                           :theme                      theme
                                           :custom-printers            {}
-                                          :value-width-limit          (-> fireworks.config/options
-                                                                          :value-width-limit
+                                          :non-coll-length-limit          (-> fireworks.config/options
+                                                                          :non-coll-length-limit
                                                                           :default)
                                           :display-namespaces?        (-> fireworks.config/options
                                                                           :display-namespaces?

--- a/test/fireworks/core_test.cljc
+++ b/test/fireworks/core_test.cljc
@@ -131,7 +131,35 @@
                 #_(pp/pprint formatted-string)
                 formatted-string)
               "%c[%c%c1%c %c2%c %c3%c %c4%c %c5%c%c ...+3%c%c]%c")))
-       
+
+       (deftest p*-with-non-coll-level-1-depth-length-limit
+         (is (= 
+              (let [ret              (p* {:label                         "my-label"
+                                          :enable-terminal-truecolor?    true
+                                          :enable-terminal-italics?      true
+                                          :bracket-contrast              "high"
+                                          :theme                         theme
+                                          :non-coll-depth-1-length-limit 60}
+                                         ["asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas"])
+                    formatted-string (-> ret :formatted :string)]
+                #_(pp/pprint formatted-string)
+                formatted-string)
+              "%c[%c%c\"asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44\"%c...%c%c%c]%c")))
+
+       (deftest p*-with-non-coll-length-limit
+       (is (= 
+            (let [ret              (p* {:label                        "my-label"
+                                        :enable-terminal-truecolor?   true
+                                        :enable-terminal-italics?     true
+                                        :bracket-contrast             "high"
+                                        :theme                        theme
+                                        :non-coll-result-length-limit 42}
+                                       "asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas")
+                  formatted-string (-> ret :formatted :string)]
+              (pp/pprint formatted-string)
+              formatted-string)
+            "%c\"asdfffaaaaasdfasdfasdfasdfasdfasdfasd\"%c...%c%c")))
+
        (deftest p*-rainbow-brackets
          (is (= 
               (let [ret              (p* {:label                      "my-label"
@@ -227,6 +255,50 @@
               #_(pp/pprint (escape-sgr formatted-string))
               (escape-sgr formatted-string))
             '("〠38;5;64〠" "\"foo\"" "〠0〠"))))
+
+     (deftest p*-with-non-coll-level-1-depth-length-limit
+       (is (= 
+            (let [ret              (p* {:label                         "my-label"
+                                        :enable-terminal-truecolor?    true
+                                        :enable-terminal-italics?      true
+                                        :bracket-contrast              "high"
+                                        :theme                         theme
+                                        :non-coll-depth-1-length-limit 60}
+                                       ["asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas"])
+                  formatted-string (-> ret :formatted :string)]
+              #_(pp/pprint (escape-sgr formatted-string))
+              (escape-sgr formatted-string))
+            '("〠38;5;241〠"
+              "["
+              "〠0〠"
+              "〠38;2;68;140;39〠"
+              "\"asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44\""
+              "〠3;38;2;140;140;140〠"
+              "..."
+              "〠0〠"
+              "〠0〠"
+              "〠38;5;241〠"
+              "]"
+              "〠0〠"))))
+
+     (deftest p*-with-non-coll-result-length-limit
+       (is (= 
+            (let [ret              (p* {:label                        "my-label"
+                                        :enable-terminal-truecolor?   true
+                                        :enable-terminal-italics?     true
+                                        :bracket-contrast             "high"
+                                        :theme                        theme
+                                        :non-coll-result-length-limit 42}
+                                       "asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas")
+                  formatted-string (-> ret :formatted :string)]
+              #_(pp/pprint (escape-sgr formatted-string))
+              (escape-sgr formatted-string))
+            '("〠38;2;68;140;39〠"
+              "\"asdfffaaaaasdfasdfasdfasdfasdfasdfasd\""
+              "〠3;38;2;140;140;140〠"
+              "..."
+              "〠0〠"
+              "〠0〠"))))
 
      (deftest p*-with-coll-limit
        (is (= 
@@ -354,7 +426,7 @@
               "〠0〠"))))
 
 
-      (deftest p*-record-sample-in-atom
+     (deftest p*-record-sample-in-atom
        (is (= 
             (let [ret              (p* {:label                      "my-label"
                                         :enable-terminal-truecolor? true

--- a/test/fireworks/core_test.cljc
+++ b/test/fireworks/core_test.cljc
@@ -113,9 +113,11 @@
                                                                           :default)}
                                          smoke-test/basic-samples)
                     formatted-string (-> ret :formatted :string)]
-                #_(pp/pprint formatted-string)
+
+                ;; (pp/pprint "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+                ;; (pp/pprint formatted-string)
                 formatted-string)
-              "%c{%c%c:uuid%c     %c#uuid%c%c\"4fe5d828-6444-11e8-8222\"%c...%c%c\n %c:fn%c       %ccljs.core/juxt%c%c[var_args]%c\n %c:brackets%c %c[%c%c[%c%c[%c%c[%c%c[%c%c[%c%c]%c%c]%c%c]%c%c]%c%c]%c%c]%c\n %c:symbol2%c  %cmysym%c%c %c%c    %c%c{:foo%c%c\n                     %c%c [\"afasdfasf\"%c%c\n                     %c%c  \"afasdfasf\"%c%c\n                     %c%c  {:a \"foo\", :b [1 2 [1 2 3 4]]}%c%c\n                     %c%c  \"afasdfasf\"%c%c\n                     %c%c  \"afasdfasf\"],%c%c\n                     %c%c :bar \"fooz\"}%c\n %c:atom1%c    %cAtom<%c%c1%c%c>%c\n %c:regex%c    %c#\"^hi$\"%c\n %c:number%c   %c1234%c\n %c:string%c   %c\"string\"%c\n %c:lamda%c    %cλ%c%c%c%c[%1]%c\n %c:atom2%c    %cAtom<%c%cFoos%c\n           %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c\n %c:symbol%c   %cmysym%c%c %c%c    %c%c{:foo :bar}%c\n %c:boolean%c  %ctrue%c\n %c:record%c   %cFoos%c\n           %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c}%c")))
+              "%c{%c%c:uuid%c     %c#uuid%c%c\"4fe5d828-6444-11e8-8222-720007e40350\"%c\n %c:fn%c       %ccljs.core/juxt%c%c[var_args]%c\n %c:brackets%c %c[%c%c[%c%c[%c%c[%c%c[%c%c[%c%c]%c%c]%c%c]%c%c]%c%c]%c%c]%c\n %c:symbol2%c  %cmysym%c%c %c%c    %c%c{:foo%c%c\n                     %c%c [\"afasdfasf\"%c%c\n                     %c%c  \"afasdfasf\"%c%c\n                     %c%c  {:a \"foo\", :b [1 2 [1 2 3 4]]}%c%c\n                     %c%c  \"afasdfasf\"%c%c\n                     %c%c  \"afasdfasf\"],%c%c\n                     %c%c :bar \"fooz\"}%c\n %c:atom1%c    %cAtom<%c%c1%c%c>%c\n %c:regex%c    %c#\"^hi$\"%c\n %c:number%c   %c1234%c\n %c:string%c   %c\"string\"%c\n %c:lamda%c    %cλ%c%c%c%c[%1]%c\n %c:atom2%c    %cAtom<%c%cFoos%c\n           %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c\n %c:symbol%c   %cmysym%c%c %c%c    %c%c{:foo :bar}%c\n %c:boolean%c  %ctrue%c\n %c:record%c   %cFoos%c\n           %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c}%c")))
        
        (deftest p*-with-coll-limit
          (is (= 

--- a/test/fireworks/core_test.cljc
+++ b/test/fireworks/core_test.cljc
@@ -108,8 +108,8 @@
                                           :metadata-print-level       (-> fireworks.config/options
                                                                           :metadata-print-level
                                                                           :default)
-                                          :mapkey-width-limit         (-> fireworks.config/options
-                                                                          :mapkey-width-limit
+                                          :non-coll-mapkey-length-limit         (-> fireworks.config/options
+                                                                          :non-coll-mapkey-length-limit
                                                                           :default)}
                                          smoke-test/basic-samples)
                     formatted-string (-> ret :formatted :string)]

--- a/test/fireworks/core_test.cljc
+++ b/test/fireworks/core_test.cljc
@@ -1,26 +1,26 @@
 (ns fireworks.core-test
   (:require [clojure.string :as string]
-            [fireworks.core :refer [? !? ?> !?> p p*]]
+            [fireworks.core :refer [? !? ?> !?> p p-data]]
             [fireworks.config]
             [fireworks.pp :as pp :refer [?pp]]
             [fireworks.smoke-test :as smoke-test]
             #?(:cljs [cljs.test :refer [deftest is]])
             #?(:clj [clojure.test :refer :all])))
 ;; These tests will break if your local ~/.fireworks/config.edn is different from fireworks.smoke-test/example-config. Change it to that temporarily if you want to run these tests locally. This will be fixed in the near future.
-;; By design, all cljs tests that test fireworks.core/p* in this namespace will break if the line number that they are on changes!
+;; By design, all cljs tests that test fireworks.core/p-data in this namespace will break if the line number that they are on changes!
 (def theme smoke-test/alabaster-light-legacy)
 (declare escape-sgr)
 
 #?(:cljs
-   (deftest p*-basic 
+   (deftest p-data-basic 
      (is (=
-          (let [ret (p* {:theme theme} "foo")] #_(pp/pprint ret) ret)
+          (let [ret (p-data {:theme theme} "foo")] #_(pp/pprint ret) ret)
           {:quoted-form   "foo",
            :formatted     {:string     "%c\"foo\"%c",
                            :css-styles ["color:#448C27;line-height:1.45;"
                                         "color:#585858;line-height:1.45;"]},
            :file          "fireworks/core_test.cljc",
-           :end-column    46,
+           :end-column    50,
            :ns-str        "fireworks.core-test",
            :file-info-str "fireworks.core-test:17:21",
            :column        21,
@@ -36,15 +36,15 @@
                                         "color:#448C27;line-height:1.45;"
                                         "color:#585858;line-height:1.45;"]}}))))
 #?(:cljs
-   (deftest p*-with-label
+   (deftest p-data-with-label
      (is (= 
-          (let [ret (p* "my-label" "foo")] (pp/pprint ret) ret)
+          (let [ret (p-data "my-label" "foo")] #_(pp/pprint ret) ret)
           {:quoted-form   "foo",
            :formatted     {:string     "%c\"foo\"%c",
                            :css-styles ["color:#448C27;line-height:1.45;"
                                         "color:#585858;line-height:1.45;"]},
            :file          "fireworks/core_test.cljc",
-           :end-column    42,
+           :end-column    46,
            :ns-str        "fireworks.core-test",
            :file-info-str "fireworks.core-test:41:21",
            :column        21,
@@ -61,9 +61,9 @@
 
 
 #?(:cljs
-   (do (deftest p*-with-label-from-opts
+   (do (deftest p-data-with-label-from-opts
          (is (= 
-              (let [ret (p* {:label             "my-label-from-opts"
+              (let [ret (p-data {:label             "my-label-from-opts"
                              :theme             theme
                              :non-coll-length-limit (-> fireworks.config/options
                                                     :non-coll-length-limit
@@ -88,9 +88,9 @@
                                             "color:#585858;line-height:1.45;"
                                             "color:#448C27;line-height:1.45;"
                                             "color:#585858;line-height:1.45;"]}})))
-       (deftest p*-basic-samples
+       (deftest p-data-basic-samples
          (is (= 
-              (let [ret              (p* {:label                      "my-label"
+              (let [ret              (p-data {:label                      "my-label"
                                           :enable-terminal-truecolor? true
                                           :enable-terminal-italics?   true
                                           :bracket-contrast           "high"
@@ -119,9 +119,9 @@
                 formatted-string)
               "%c{%c%c:uuid%c     %c#uuid%c%c\"4fe5d828-6444-11e8-8222-720007e40350\"%c\n %c:fn%c       %ccljs.core/juxt%c%c[var_args]%c\n %c:brackets%c %c[%c%c[%c%c[%c%c[%c%c[%c%c[%c%c]%c%c]%c%c]%c%c]%c%c]%c%c]%c\n %c:symbol2%c  %cmysym%c%c %c%c    %c%c{:foo%c%c\n                     %c%c [\"afasdfasf\"%c%c\n                     %c%c  \"afasdfasf\"%c%c\n                     %c%c  {:a \"foo\", :b [1 2 [1 2 3 4]]}%c%c\n                     %c%c  \"afasdfasf\"%c%c\n                     %c%c  \"afasdfasf\"],%c%c\n                     %c%c :bar \"fooz\"}%c\n %c:atom1%c    %cAtom<%c%c1%c%c>%c\n %c:regex%c    %c#\"^hi$\"%c\n %c:number%c   %c1234%c\n %c:string%c   %c\"string\"%c\n %c:lamda%c    %cλ%c%c%c%c[%1]%c\n %c:atom2%c    %cAtom<%c%cFoos%c\n           %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c\n %c:symbol%c   %cmysym%c%c %c%c    %c%c{:foo :bar}%c\n %c:boolean%c  %ctrue%c\n %c:record%c   %cFoos%c\n           %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c}%c")))
        
-       (deftest p*-with-coll-limit
+       (deftest p-data-with-coll-limit
          (is (= 
-              (let [ret              (p* {:label                      "my-label"
+              (let [ret              (p-data {:label                      "my-label"
                                           :enable-terminal-truecolor? true
                                           :enable-terminal-italics?   true
                                           :coll-limit                 5
@@ -132,9 +132,9 @@
                 formatted-string)
               "%c[%c%c1%c %c2%c %c3%c %c4%c %c5%c%c ...+3%c%c]%c")))
 
-       (deftest p*-with-non-coll-level-1-depth-length-limit
+       (deftest p-data-with-non-coll-level-1-depth-length-limit
          (is (= 
-              (let [ret              (p* {:label                         "my-label"
+              (let [ret              (p-data {:label                         "my-label"
                                           :enable-terminal-truecolor?    true
                                           :enable-terminal-italics?      true
                                           :bracket-contrast              "high"
@@ -146,9 +146,9 @@
                 formatted-string)
               "%c[%c%c\"asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44\"%c...%c%c%c]%c")))
 
-       (deftest p*-with-non-coll-length-limit
+       (deftest p-data-with-non-coll-length-limit
        (is (= 
-            (let [ret              (p* {:label                        "my-label"
+            (let [ret              (p-data {:label                        "my-label"
                                         :enable-terminal-truecolor?   true
                                         :enable-terminal-italics?     true
                                         :bracket-contrast             "high"
@@ -160,9 +160,9 @@
               formatted-string)
             "%c\"asdfffaaaaasdfasdfasdfasdfasdfasdfasd\"%c...%c%c")))
 
-       (deftest p*-rainbow-brackets
+       (deftest p-data-rainbow-brackets
          (is (= 
-              (let [ret              (p* {:label                      "my-label"
+              (let [ret              (p-data {:label                      "my-label"
                                           :enable-terminal-truecolor? true
                                           :enable-terminal-italics?   true
                                           :bracket-contrast           "high"
@@ -173,9 +173,9 @@
                 formatted-string)
               "%c[%c%c[%c%c[%c%c[%c%c[%c%c]%c%c]%c%c]%c%c]%c%c]%c")))
        
-       (deftest p*-record-sample-in-atom
+       (deftest p-data-record-sample-in-atom
          (is (= 
-              (let [ret              (p* {:label                      "my-label"
+              (let [ret              (p-data {:label                      "my-label"
                                           :enable-terminal-truecolor? true
                                           :enable-terminal-italics?   true
                                           :bracket-contrast           "high"
@@ -186,9 +186,9 @@
                 formatted-string)
               "%cAtom<%c%cFoos%c\n%c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c")))
        
-       (deftest p*-js-array
+       (deftest p-data-js-array
          (is (= 
-              (let [ret              (p* {:label                      "my-label"
+              (let [ret              (p-data {:label                      "my-label"
                                           :enable-terminal-truecolor? true
                                           :enable-terminal-italics?   true
                                           :bracket-contrast           "high"
@@ -199,9 +199,9 @@
                 formatted-string)
               "%c#js%c%c[%c%c1%c, %c2%c, %c3%c%c]%c")))
 
-       (deftest p*-js-set
+       (deftest p-data-js-set
          (is (= 
-              (let [ret              (p* {:label                      "my-label"
+              (let [ret              (p-data {:label                      "my-label"
                                           :enable-terminal-truecolor? true
                                           :enable-terminal-italics?   true
                                           :bracket-contrast           "high"
@@ -212,10 +212,10 @@
                 formatted-string)
               "%cjs/Set%c\n%c#{%c%c1%c, %c2%c%c}%c")))
        
-       (deftest p*-custom-printers
+       (deftest p-data-custom-printers
          (is (= 
               (let [ret              
-                    (p* {:custom-printers {:vector {:pred        (fn [x] (= x [1 2 3 4]))
+                    (p-data {:custom-printers {:vector {:pred        (fn [x] (= x [1 2 3 4]))
                                                     :f           (fn [x] (into #{} x))
                                                     :badge-text  " Set💩 "
                                                     :badge-style {:color            "#000"
@@ -233,9 +233,9 @@
    
    :clj
    (do 
-     (deftest p*-with-label-from-opts
+     (deftest p-data-with-label-from-opts
        (is (= 
-            (let [ret              (p* {:label                      "my-label-from-opts"
+            (let [ret              (p-data {:label                      "my-label-from-opts"
                                         :enable-terminal-truecolor? true
                                         :enable-terminal-italics?   true}
                                        "foo")
@@ -244,9 +244,9 @@
               (escape-sgr formatted-string))
             '("〠38;2;68;140;39〠" "\"foo\"" "〠0〠"))))
 
-     (deftest p*-with-label-from-opts-primitive-terminal-emulator
+     (deftest p-data-with-label-from-opts-primitive-terminal-emulator
        (is (= 
-            (let [ret              (p* {:label                      "my-label-from-opts"
+            (let [ret              (p-data {:label                      "my-label-from-opts"
                                         :enable-terminal-truecolor? false
                                         :enable-terminal-italics?   false
                                         :theme                      theme}
@@ -256,9 +256,9 @@
               (escape-sgr formatted-string))
             '("〠38;5;64〠" "\"foo\"" "〠0〠"))))
 
-     (deftest p*-with-non-coll-level-1-depth-length-limit
+     (deftest p-data-with-non-coll-level-1-depth-length-limit
        (is (= 
-            (let [ret              (p* {:label                         "my-label"
+            (let [ret              (p-data {:label                         "my-label"
                                         :enable-terminal-truecolor?    true
                                         :enable-terminal-italics?      true
                                         :bracket-contrast              "high"
@@ -281,9 +281,9 @@
               "]"
               "〠0〠"))))
 
-     (deftest p*-with-non-coll-result-length-limit
+     (deftest p-data-with-non-coll-result-length-limit
        (is (= 
-            (let [ret              (p* {:label                        "my-label"
+            (let [ret              (p-data {:label                        "my-label"
                                         :enable-terminal-truecolor?   true
                                         :enable-terminal-italics?     true
                                         :bracket-contrast             "high"
@@ -300,9 +300,9 @@
               "〠0〠"
               "〠0〠"))))
 
-     (deftest p*-with-coll-limit
+     (deftest p-data-with-coll-limit
        (is (= 
-            (let [ret              (p* {:label                      "my-label"
+            (let [ret              (p-data {:label                      "my-label"
                                         :enable-terminal-truecolor? true
                                         :enable-terminal-italics?   true
                                         :coll-limit                 5
@@ -341,9 +341,9 @@
               "]"
               "〠0〠"))))
      
-     (deftest p*-rainbow-brackets
+     (deftest p-data-rainbow-brackets
        (is (= 
-            (let [ret              (p* {:label                      "my-label"
+            (let [ret              (p-data {:label                      "my-label"
                                         :enable-terminal-truecolor? true
                                         :enable-terminal-italics?   true
                                         :bracket-contrast           "high"
@@ -383,9 +383,9 @@
               "]"
               "〠0〠"))))
      
-     (deftest p*-rainbow-brackets-low-contrast
+     (deftest p-data-rainbow-brackets-low-contrast
        (is (= 
-            (let [ret              (p* {:label                      "my-label"
+            (let [ret              (p-data {:label                      "my-label"
                                         :enable-terminal-truecolor? true
                                         :enable-terminal-italics?   true
                                         :bracket-contrast           "low"
@@ -426,9 +426,9 @@
               "〠0〠"))))
 
 
-     (deftest p*-record-sample-in-atom
+     (deftest p-data-record-sample-in-atom
        (is (= 
-            (let [ret              (p* {:label                      "my-label"
+            (let [ret              (p-data {:label                      "my-label"
                                         :enable-terminal-truecolor? true
                                         :enable-terminal-italics?   true
                                         :bracket-contrast           "high"
@@ -468,9 +468,9 @@
               "〠3;38;2;37;101;70;48;2;214;245;214〠"
               ">"
               "〠0〠"))))
-     (deftest p*-record-sample
+     (deftest p-data-record-sample
        (is (= 
-            (let [ret              (p* {:label                      "my-label"
+            (let [ret              (p-data {:label                      "my-label"
                                         :enable-terminal-truecolor? true
                                         :enable-terminal-italics?   true
                                         :bracket-contrast           "high"
@@ -504,9 +504,9 @@
               "〠38;5;241;48;2;237;237;237〠"
               "}"
               "〠0〠"))))
-     (deftest p*-symbol-with-meta
+     (deftest p-data-symbol-with-meta
        (is (= 
-            (let [ret              (p* {:label                      "my-label"
+            (let [ret              (p-data {:label                      "my-label"
                                         :enable-terminal-truecolor? true
                                         :enable-terminal-italics?   true
                                         :bracket-contrast           "high"

--- a/test/fireworks/smoke_test.cljc
+++ b/test/fireworks/smoke_test.cljc
@@ -12,7 +12,7 @@
  :mood                       :light
  :line-height                1.45
  :print-level                7
- :value-width-limit          33
+ :non-coll-length-limit          33
  :mapkey-width-limit         20
  :coll-limit                 15
  :evaled-form-coll-limit     7
@@ -316,8 +316,8 @@
   (p {:label "theme Alabaster Light" :theme "Alabaster Light"}
      (atom [[1 2 3] "abcdefghijk"]))
 
-  ;; :value-width-limit
-  (p {:label :value-width-limit :value-width-limit 20}
+  ;; :non-coll-length-limit
+  (p {:label :non-coll-length-limit :non-coll-length-limit 20}
      "abcdefghijklmnopqrstuvwxyz")
 
 

--- a/test/fireworks/smoke_test.cljc
+++ b/test/fireworks/smoke_test.cljc
@@ -1,5 +1,5 @@
 (ns fireworks.smoke-test
-  (:require [fireworks.core :refer [? !? ?> !?> p p*]]
+  (:require [fireworks.core :refer [? !? ?> !?> p p-data]]
             [clojure.string :as string] [fireworks.pp :as pp]
             #?(:cljs [cljs.test :refer [deftest is]])
             #?(:clj [clojure.test :refer :all])))

--- a/test/fireworks/smoke_test.cljc
+++ b/test/fireworks/smoke_test.cljc
@@ -13,7 +13,7 @@
  :line-height                1.45
  :print-level                7
  :non-coll-length-limit          33
- :mapkey-width-limit         20
+ :non-coll-mapkey-length-limit         20
  :coll-limit                 15
  :evaled-form-coll-limit     7
  :display-namespaces?        true
@@ -321,8 +321,8 @@
      "abcdefghijklmnopqrstuvwxyz")
 
 
-  ;; :mapkey-width-limit
-  (p {:label :mapkey-width-limit :mapkey-width-limit         20}
+  ;; :non-coll-mapkey-length-limit
+  (p {:label :non-coll-mapkey-length-limit :non-coll-mapkey-length-limit         20}
      {"abcdefghijklmnopqrstuvwxyz" [1 2 3] })
 
   (? {:evaled-form-coll-limit     7}


### PR DESCRIPTION
- Adds new config options for relaxing length limits for non-coll vals in various contexts #3

- Updates [tagging utility lib dep](https://github.com/paintparty/lasertag) and all refs `typetag`->`lasertag`