### PR TITLE
Config refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 For a list of breaking changes, check [here](#breaking-changes)
 
+## 0.8.1
+#### Fixes
+- Fixes empty map bug
+
+#### Added
+- Exposes `:margin-top` and `:margin-bottom` options
+
+#### Changed
+- Increase depth of caught-exception (in `fireworks.core/formatted`) stack trace preview to 12 frames
+
+
 ## 0.8.0
 #### Added
 - [Add `"Universal Neutral"` theme](https://github.com/paintparty/fireworks/issues/21) that works on both light and dark backgrounds

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.paintparty/fireworks "0.8.0"
+(defproject io.github.paintparty/fireworks "0.8.1-SNAPSHOT"
   :description "Themeable print debugging library for Clojure, ClojureScript, and Babashka"
   :url "https://github.com/paintparty/fireworks"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/fireworks/config.cljc
+++ b/src/fireworks/config.cljc
@@ -11,9 +11,9 @@
                                    :default        "light"
                                    :updates-theme? true}
    :coll-limit                    {:spec    ::config/coll-limit
-                                   :default 15}
+                                   :default 33}
    :single-line-coll-length-limit {:spec    ::config/single-line-coll-length-limit
-                                   :default 15}
+                                   :default 33}
    :non-coll-result-length-limit  {:spec    ::config/non-coll-result-length-limit
                                    :default 444}
    :non-coll-depth-1-length-limit {:spec    ::config/non-coll-depth-1-length-limit
@@ -55,6 +55,10 @@
                                    :updates-theme? true}
    :label-length-limit            {:spec    ::config/label-length-limit
                                    :default 25}
+   :margin-bottom                 {:spec    ::config/margin-bottom
+                                   :default 1}
+   :margin-top                    {:spec    ::config/margin-top
+                                   :default 0}
    :custom-printers               {:spec    ::config/custom-printers
                                    :default {}}
    :find                          {:spec    ::config/custom-printers

--- a/src/fireworks/core.cljc
+++ b/src/fireworks/core.cljc
@@ -12,7 +12,7 @@
              :refer-macros
              [keyed
               compile-time-warnings-and-errors]])
-   #?(:clj [fireworks.macros :refer [keyed]])
+   #?(:clj [fireworks.macros :refer [keyed get-user-config-edn-dynamic]])
    [clojure.string :as string]
    [fireworks.config :as config]
    [clojure.spec.alpha :as s]
@@ -802,12 +802,15 @@
         (some-> defd str)))))
 
 
-(defn- helper2
-  "Extracts the :label entry when present fireworks config opts"
-  [m]
-  (let [cfg-opts (cfg-opts m)
-        defd     (defd (:x m))]
-    (keyed [cfg-opts defd])))
+#?(:clj
+   (defn- helper2
+     "Extracts the :label entry when present fireworks config opts"
+     [m]
+    ;;  (ff 'helper2 (get-user-config-edn-dynamic))
+     (let [cfg-opts (cfg-opts m)
+           defd     (defd (:x m))]
+       (keyed [cfg-opts defd]))))
+
 
 
 (defn cast-var
@@ -852,47 +855,43 @@
     {:mode     mode
      :template template}))
 
-(defn- ?2-helper
-  [{:keys [cfg-opts* mode template label &form x]}]
-  (let [defd
-        (defd x)
+#?(:clj
+   (defn- ?2-helper
+     [{:keys [cfg-opts* mode template label &form x]}]
+    ;;  (ff '?-helper2 (get-user-config-edn-dynamic))
+     (let [defd           (defd x)
 
-        log?*
-        (contains? #{:log :pp} mode)
+           log?*          (contains? #{:log :pp} mode)
 
-        quoted-fw-form
-        (if (contains? #{:result :log- :pp-} mode)
-         (list 'quote nil)
-         (list 'quote &form))
+           quoted-fw-form (if (contains? #{:result :log- :pp-} mode)
+                            (list 'quote nil)
+                            (list 'quote &form))
 
-        fw-fnsym
-        (when-not (contains? #{:result :log- :pp-} mode)
-         "fireworks.core/?")
+           fw-fnsym       (when-not (contains? #{:result :log- :pp-} mode)
+                            "fireworks.core/?")
 
-        form-meta
-        (when-not (contains? #{:result :log- :pp-} mode)
-          (meta &form))
+           form-meta      (when-not (contains? #{:result :log- :pp-} mode)
+                            (meta &form))
 
-        qf-nil?
-        (contains? #{:comment :result} mode)
+           qf-nil?        (contains? #{:comment :result} mode)
 
-        cfg-opts
-        (merge (dissoc (or cfg-opts* {}) :label)
-               {:mode           mode
-                :label          label
-                :template       template
-                :ns-str         (some-> *ns* ns-name str)
-                :user-opts      cfg-opts*
-                :quoted-fw-form quoted-fw-form
-                :fw-fnsym       fw-fnsym}
-                (when form-meta
-                  {:form-meta form-meta})
-                (when log?*
-                  {:log?    log?*
-                   :fw/log? log?*})
-                (when (= mode :data)
-                  {:p-data? true}))]
-   (keyed [defd x qf-nil? cfg-opts log?*])))
+           cfg-opts       (merge (dissoc (or cfg-opts* {}) :label)
+                                 {:mode           mode
+                                  :label          label
+                                  :template       template
+                                  :ns-str         (some-> *ns* ns-name str)
+                                  :user-opts      cfg-opts*
+                                  :quoted-fw-form quoted-fw-form
+                                  :fw-fnsym       fw-fnsym}
+                                 (when form-meta
+                                   {:form-meta form-meta})
+                                 (when log?*
+                                   {:log?    log?*
+                                    :fw/log? log?*})
+                                 (when (= mode :data)
+                                   {:p-data? true}))]
+       (keyed [defd x qf-nil? cfg-opts log?*]))))
+
                                                                
                                                                
 ;                  AAA               PPPPPPPPPPPPPPPPP   IIIIIIIIII

--- a/src/fireworks/core.cljc
+++ b/src/fireworks/core.cljc
@@ -49,8 +49,8 @@
 ;   FFFFFFFFFFF           
 
 
-(defn- margin-bottom-str [user-opts]
-  (if-let [mb (:margin-bottom user-opts)]
+(defn- margin-block-str [user-opts k]
+  (if-let [mb (k user-opts)]
     (if (or (zero? mb) (pos-int? mb))
       (string/join (repeat mb "\n"))
       "\n")
@@ -299,7 +299,10 @@
        ;; needs to be set in fireworks.core/_log or fireworks.core/_pp
        :margin-bottom (if (contains? #{:log :pp} mode)
                         "\n"
-                        (margin-bottom-str user-opts))})))
+                        (margin-block-str user-opts :margin-bottom))
+       :margin-top    (if (contains? #{:log :pp} mode)
+                        "\n"
+                        (margin-block-str user-opts :margin-top))})))
 
 
 #?(:cljs 
@@ -488,7 +491,12 @@
         (f x)
         :clj
         (do 
+          ;; If it has been formatted by fireworks, it will print here.
+          (print (:margin-top x))
           (some-> fmt print)
+
+          ;; Extra line based on :margin-bottom
+          ;; TODO - not print if fmt is nil or blank string?
           ((if log? print println) (:margin-bottom x)))))))
 
 (defn ^{:public true}
@@ -500,9 +508,10 @@
          x)
      :clj
      (do
+       (print (margin-block-str user-opts :margin-top))
        (pprint x)
        ;; Extra line after pprint result
-       (print (margin-bottom-str user-opts))
+       (print (margin-block-str user-opts :margin-bottom))
        x)))
 
 (defn ^{:public true} _log 
@@ -512,9 +521,10 @@
          x)
      :clj
      (do
+       (print (margin-block-str user-opts :margin-top))
        (pprint x)
        ;; Extra line after pprint result
-       (print (margin-bottom-str user-opts))
+       (print (margin-block-str user-opts :margin-bottom))
        x)))
 
 ;; TODO - Is it possible to retire this in favor of directing all internal calls

--- a/src/fireworks/macros.clj
+++ b/src/fireworks/macros.clj
@@ -190,3 +190,103 @@
     ;; If (System/getenv "FIREWORKS_CONFIG") resolves to nil, we set theme to
     ;; default \"Universal Neutral\"" stock theme.
     {:theme "Universal Neutral"}))
+
+(defn get-user-config-edn-dynamic
+  "This gets the path to user config from sys env var, then returns a map of
+   user config with resolved :theme entry.
+   
+   First, the path set by the user via \"FIREWORKS_CONFIG\" env var is
+   validated. If it is a non-blank string that does not point to .edn file,
+   issue a bad-option-value-warning. Also update messaging/warning-and-errors
+   atom, which will surface the warning if the user is in cljs land, and maybe
+   not looking at the build process in their terminal.
+
+   If the path set by the user via \"FIREWORKS_CONFIG\" env var points to a
+   non-existant `.edn` file, or a file that is not parseable by
+   `clojure.edn/read`, a warning is issued via fireworks.macros/load-edn.
+   Also update the `messaging/warning-and-errors` atom, which will surface the
+   warning if the user is in cljs land, and maybe not looking at the build
+   process in their terminal.
+   
+   If the config map is successfully loaded from edn file, and the :theme entry
+   is a valid `.edn` path, but this path points to a non-existant `.edn` file,
+   or a file that is not parseable by `clojure.edn/read`, a warning is issued
+   via fireworks.macros/load-edn.
+
+   If a valid :theme map is resolved, it will be assoc'd to the user's config
+   map, and returned. Otherwised, just the config map is returned. 
+   "
+  []
+  (use 'clojure.java.io)
+  (reset! messaging/warnings-and-errors [])
+  (if-let [path-to-user-config (System/getenv "FIREWORKS_CONFIG")]
+    (let [valid-path? (s/valid?
+                       ::config/edn-file-path 
+                       path-to-user-config)]
+
+      (if-not valid-path?  
+        (let [opts {:v      path-to-user-config
+                    :k      "FIREWORKS_CONFIG="
+                    :spec   ::config/edn-file-path
+                    :header (str "[fireworks.core/_p] Invalid value"
+                                 " for environmental variable.")}]
+
+          (messaging/bad-option-value-warning opts)
+
+          (swap! messaging/warnings-and-errors
+                 conj
+                 [:messaging/bad-option-value-warning opts]))
+
+        (when-let [config (load-edn {:source path-to-user-config})]
+          (let [config (assoc config :path-to-user-config path-to-user-config)]
+            (if-let [theme* (:theme config)]
+              (if-let [user-theme*
+                       (when-let [x 
+                                  (cond
+                                    (s/valid? ::config/edn-file-path theme*)
+                                    (load-edn {:source theme*
+                                               :file   path-to-user-config
+                                               :key    :theme})
+
+                                    (map? theme*)
+                                    theme*
+
+                                    (string? theme*)
+                                    (get basethemes/stock-themes theme* nil))]
+                         (when (s/valid? ::theme/theme x)
+                           x))]
+
+                ;; :theme entry resolves to a map, so assoc it to user config
+                (let [config (assoc config :theme user-theme*)]
+                  config)
+
+                ;; :theme entry exists, but doesn't resolve to a map
+                ;; dissoc :theme entry and issue warning for user
+                (let [config (assoc config 
+                                    :theme
+                                    (get basethemes/stock-themes
+                                         "Universal Neutral"
+                                         nil))
+                      opts {:v      theme*
+                            :k      ":theme"
+                            :spec   ::config/theme
+                            :header (str "[fireworks.core/_p] Invalid value "
+                                         "for :theme entry.")
+                            :body   (bling "The default theme "
+                                           [:italic "\"Universal Neutral\" "]
+                                           "will be used instead.")}]
+
+                  (messaging/bad-option-value-warning opts)
+
+                  (swap! messaging/warnings-and-errors
+                         conj
+                         [:messaging/bad-option-value-warning opts])                 
+
+                  config))
+
+              ;; :theme entry is nil or non-existant, just return user config map
+              config)))))
+
+    ;; If (System/getenv "FIREWORKS_CONFIG") resolves to nil, we set theme to
+    ;; default \"Universal Neutral\"" stock theme.
+    {:theme "Universal Neutral"}))

--- a/src/fireworks/messaging.cljc
+++ b/src/fireworks/messaging.cljc
@@ -1,6 +1,6 @@
 (ns fireworks.messaging
   (:require [clojure.string :as string]
-            [fireworks.pp :refer [?pp]]
+            [fireworks.pp :refer [?pp pprint]]
             [expound.alpha :as expound]
             [bling.core :refer [stack-trace-preview bling point-of-interest callout]]))
 
@@ -9,6 +9,14 @@
 ;; Compile time errors for surfacing to cljs browser console
 (def warnings-and-errors (atom []))
 
+(defn fw-debug-report-template
+  ([s x]
+   (fw-debug-report-template s x :info))
+  ([s x k]
+   (callout {:label       s
+             :padding-top 1
+             :type        k}
+            (with-out-str (pprint x)))))
 
 (defn bad-option-value-warning
   [{:keys [k v spec default header body line column file form]}]

--- a/src/fireworks/messaging.cljc
+++ b/src/fireworks/messaging.cljc
@@ -101,11 +101,10 @@
                            "\n"
                            (string/replace (.getMessage err) #"\(" "\n(")
                            "\n\n"
-                           [:italic.subtle.bold "Stacktrace preview:"]
-                           "\n"
                            (stack-trace-preview
                             {:error err
-                             :regex #"^fireworks\.|^lasertag\."})
+                             :regex #"^fireworks\.|^lasertag\."
+                             :depth 12})
                            (some->> body (str "\n\n"))))
                        body)})))))
 

--- a/src/fireworks/specs/config.cljc
+++ b/src/fireworks/specs/config.cljc
@@ -42,6 +42,12 @@
 (s/def ::line-height
   (s/and number? #(<= 0.5 % 3.0)))
 
+(s/def ::margin-bottom
+  (s/and int? #(<= 0 % 100)))
+
+(s/def ::margin-top
+  (s/and int? #(<= 0 % 100)))
+
 (s/def ::single-line-coll-length-limit
   (s/and int? #(<= 2 % 200)))
 

--- a/src/fireworks/state.cljc
+++ b/src/fireworks/state.cljc
@@ -1,6 +1,8 @@
+;; TODO - what is difference between @config and user-config-edn
+
 (ns ^:dev/always fireworks.state
   (:require #?(:cljs [fireworks.macros :refer-macros [get-user-configs keyed]]
-      :clj  [fireworks.macros :refer        [get-user-configs keyed]])
+               :clj  [fireworks.macros :refer        [get-user-configs keyed]])
             [clojure.spec.alpha :as s]
             [clojure.string :as string]
             [fireworks.basethemes :as basethemes]
@@ -17,17 +19,8 @@
 
 ;; Internal state atoms for development debugging ------------------------
 
-;; Temp for debugging theme tokens
-(def debug-on-token? (atom false))
-(def token-debugging-target
-  #_:nothing
-  #_:annotation
-  #_:definition
-  #_:constant
-  #_:comment)
-
-(defn reset-token-debugging! [k]
-  (reset! debug-on-token? (= k token-debugging-target)))
+(def debug-config? false)
+(def print-config? false)
 
 ;; Temp for debugging tagging 
 (def *debug-tagging? (atom false))
@@ -36,7 +29,9 @@
   @*debug-tagging?)
 
 
-;; Internal state atoms for printing and formatting ------------------------
+;; -----------------------------------------------------------------------------
+;; Internal state atoms for printing and formatting
+;; -----------------------------------------------------------------------------
 
 ;; For ClojureScript, browser dev console %c formatting
 (def styles (atom []))
@@ -55,7 +50,7 @@
 (def top-level-value-is-sev? (atom false))
 
 ;; This will make map brackets transparent, when printing
-;; result of `?let`, `?if-let`, or `?when-let`
+;; results related to let bindings
 (def let-bindings? (atom false))
 
 ;; This will indent the whole output - label, file-info, and result
@@ -68,8 +63,21 @@
 ;; Recommended location for path is "~/.fireworks/config.edn"
 
 
-(def user-config (get-user-configs))
+;; -----------------------------------------------------------------------------
+;; Config options from user's config.edn
+;; -----------------------------------------------------------------------------
 
+(def user-config-edn* 
+  (do (when debug-config?
+        (messaging/fw-debug-report-template
+         "def fireworks.state/user-config-edn* (with :path-to-user-config)"
+         (get-user-configs)))
+      (get-user-configs)))
+
+
+;; -----------------------------------------------------------------------------
+;; Validated config options from user's config.edn
+;; -----------------------------------------------------------------------------
 
 ;; TODO - figure out how to get filename, line, and column.
 (defn validate-option-from-user-config-edn
@@ -81,7 +89,7 @@
     (if invalid?
       (messaging/bad-option-value-warning
        (assoc (keyed [k v default spec])
-              :header (str (some-> user-config
+              :header (str (some-> user-config-edn*
                                    :path-to-user-config
                                    (str "\n\n"))
                            (str "Invalid value for " k " in user config."))))
@@ -89,16 +97,35 @@
         nil
         v))))
 
+(defn- config-diffs [m1 m2]
+  (into {}
+        (keep (fn [[k v]]
+                (when (and (not= v (get m1 k nil))
+                           (not= :path-to-user-config k))
+                  [k v]))
+              m2)))
 
-;; Validated config options from user's config.edn
-(def user-options
+(def user-config-edn
   (try 
-    (into {}
-          (map (fn [[k v]]
-                 (let [m         (k config/options)
-                       validated (validate-option-from-user-config-edn k v m)]
-                   [k validated]))
-               user-config))
+    (let [ret
+          (into {}
+                (map (fn [[k v]]
+                       (let [m         
+                             (k config/options)
+
+                             validated
+                             (validate-option-from-user-config-edn k v m)]
+                         [k validated]))
+                     user-config-edn*))]
+      (when debug-config?
+        (messaging/fw-debug-report-template
+         "Invalid options from user-config-edn*"
+         (config-diffs user-config-edn* ret)))
+      (when debug-config?
+        (messaging/fw-debug-report-template
+         "def fireworks.state/user-cofig-edn (validated)"
+         ret))
+      ret)
 
     ;; TODO - check if this actually catches anything?
     (catch #?(:cljs js/Object
@@ -111,39 +138,58 @@
       {})))
 
 
-(def fallbacks
+;; -----------------------------------------------------------------------------
+;; Internal state atom for merged config
+;; -----------------------------------------------------------------------------
+
+(def ^:private default-config
   (into {} (map (fn [[k v]] [k (:default v)]) config/options)))
+
 
 (defn- dark? [x]
   (contains? #{:dark "dark"} x))
 
-(defn user-opt-val [k]
-  (let [opt (k user-options)
-        opt (when-not 
-             (and (string? opt)
-                  (string/blank? opt))
-              opt)]
-    (or opt
-        (if (= k :theme)
-            ;; TODO !!!
-            ;; Should these resolve to map to be consistent?
-          (if (dark? (:mood user-options))
-            "Alabaster Dark"
-            "Alabaster Light")
-          (k fallbacks)))))
 
+(defn- user-opt-val [k]
+  (let [opt (k user-config-edn)
+        ;; todo - why the string check?
+        opt (when-not (and (string? opt)
+                           (string/blank? opt))
+              opt)
+        ret (if (not (nil? opt))
+              opt
+              (if (= k :theme)
+                ;; maybe nix cos theme should already be there
+                (if (dark? (:mood user-config-edn))
+                  "Alabaster Dark"
+                  "Alabaster Light")
+                (k default-config)))]
+    #_(println k opt ret)
+    ret))
 
-;; Internal state atom for user options ------------------------------------
-(defn config* []
+(defn merged-config []
   (into {}
         (map (fn [[k _]]
                [k (user-opt-val k)])
              config/options)))
+
 (def config
-  (atom (config*)))
+  (do 
+    (when debug-config?
+      (messaging/fw-debug-report-template
+       "Options from user-config-edn that will override defaults"
+       (config-diffs default-config user-config-edn*)))
+    (when debug-config?
+      (messaging/fw-debug-report-template
+       "def config, initial value of atom"
+       (merged-config)))
+    (atom (merged-config))))
 
 
-;; Theme merging functions -------------------------------------------------
+;; -----------------------------------------------------------------------------
+;; Theme merging functions
+;; -----------------------------------------------------------------------------
+
 (defn- resolved-hex [c k]
   (when-not (and (= k :background-color)
                  (contains? #{:transparent "transparent"} c))
@@ -185,6 +231,7 @@
       :else
       m)))
 
+
 (defn invalid-color-warning 
   [{:keys [header v k footer theme-token from-custom-badge-style?]}]
   (str header
@@ -220,6 +267,7 @@
                  (with-removed-or-resolved-color :background-color opts))]
     ret))
 
+
 (defn x->sgr [x k]
   (when x
     (let [n (if (= k :fg) 38 48)]
@@ -229,25 +277,20 @@
               ret       (str n ";2;" r ";" g ";" b)]
           ret)))))
 
-(defn legacy? [k]
-  (or (:legacy-terminal? @config)
-      (false? (k @config))))
-
 (defn m->sgr
   [{fgc*        :color
     bgc*        :background-color
     font-style  :font-style
     font-weight :font-weight
     :as         m}]
-  (when @debug-on-token?
-    (println "\n(fireworks.state/m->sgr " m ")"))
-  (let [fgc    (x->sgr fgc* :fg)
+  (let [debug? false
+        fgc    (x->sgr fgc* :fg)
         bgc    (do #_(when bgc* (println "m->sgr:bgc* " bgc*))
-                   (x->sgr bgc* :bg))
-        italic (when (and (not (false? (:enable-terminal-italics? @config)))
+                (x->sgr bgc* :bg))
+        italic (when (and (:enable-terminal-italics? @config)
                           (contains? #{"italic" :italic} font-style))
                  "3;")
-        weight (when (and (not (false? (:enable-terminal-font-weights? @config)))
+        weight (when (and (:enable-terminal-font-weights? @config)
                           (contains? #{"bold" :bold} font-weight))
                  ";1")
         ret    (str "\033[" 
@@ -259,7 +302,7 @@
                       ";")
                     bgc
                     "m")]
-    (when  @debug-on-token?
+    (when debug?
       (?pp "\nCombining the fg and bg into a single sgr..." m)
       (println "=>\n"
                (util/readable-sgr ret)
@@ -287,53 +330,45 @@
 (defn map-vals [f m]
   (into {} (map f m)))
 
+(defn enable-truecolor-debug-message [v]
+  (println
+   (str "enable-terminal-truecolor? is set to true, so converting to [r g b a] "
+        "vector via (color/hexa->rgba v) => " v)))
+
+(defn disable-truecolor-debug-message [v]
+  (println
+   (str "enable-terminal-truecolor? is set to false, so converting to x256 id "
+        "(int) via (color/hexa->x256 v) => " v)))
 
 (defn hexa-or-sgr
   [[k v]]
-  (let [debug? @debug-on-token?
-        x (if (or (= k :color)
-                  (= k :background-color))
-            (cond
-              (string? v)
-              (do 
-                (when debug? 
-                  (println
-                   (str "(string? v) Value for " k " is " v)))
-                #?(:cljs
-                   (do 
-                     (when debug? (println (str "Returning " v)))
-                     v) 
-                   :clj
-                   (do 
-                     (if (legacy? :enable-terminal-truecolor?) 
-                       (do 
-                         (when debug?
-                           (println 
-                            (str "enable-terminal-truecolor? is set to"
-                                 " false, so converting to x256 id (int)"
-                                 " via (color/hexa->x256 v) => "
-                                 (color/hexa->x256 v))))
-                         (color/hexa->x256 v))
-                       (do 
-                         (when debug?
-                           (println
-                            (str "enable-terminal-truecolor? is set to"
-                                 " true, so converting to [r g b a] vector"
-                                 " via (color/hexa->rgba v) => "
-                                 (color/hexa->rgba v))))
-                         (color/hexa->rgba v)))))))
-            v)]
+  (let [debug? false
+        x      (if (and (or (= k :color) (= k :background-color))
+                        (string? v))
+                 (do
+                   (when debug? 
+                     (println (str "(string? v) Value for " k " is " v)))
+                   #?(:cljs
+                      (do 
+                        (when debug? (println (str "Returning " v)))
+                        v) 
+                      :clj
+                      (if (:enable-terminal-truecolor? @config) 
+                        (let [ret (color/hexa->rgba v)] 
+                          (when debug? (enable-truecolor-debug-message ret))
+                          ret)
+                        (let [ret (color/hexa->x256 v)]
+                          (when debug? (disable-truecolor-debug-message ret))
+                          ret))))
+                 v)]
     [k x]))
 
 
 (defn- fully-hydrated-map [m]
   (let [f (fn [[k v]] 
-            (reset-token-debugging! k)
             [k
              (if (map? v)
-               (do (when @debug-on-token?
-                     (println "(map-vals hexa-or-sgr v) =>"))
-                   (map-vals hexa-or-sgr v))
+               (map-vals hexa-or-sgr v)
                v)])]
     (map-vals f m)))
 
@@ -378,9 +413,6 @@
                 #?(:cljs (let [m (with-line-height m)]
                            [k (string/join (map kv->css2 m))])
                    :clj (do
-                          (reset-token-debugging! k)
-                          (when @debug-on-token?
-                            (println "\n" "(serialize-style-maps) => \n" k m))
                           [k (m->sgr m-with-k)]))))
             merged))
 
@@ -401,8 +433,11 @@
        ret     (reduce-from-base (merge base tokens*) classes)]
    ret))
 
-(defn- add-metadata-key-entries [m]
-  (assoc m
+(defn- add-metadata-key-entries
+  [m]
+  m
+  ;; Augment the font-style or font-weight (leave off for now)
+  #_(assoc m
          :metadata-key
          (assoc (:metadata m) :font-weight :bold)
          :metadata-key2
@@ -436,6 +471,9 @@
         printer (hydrated* base theme classes :printer)
         merged  (add-metadata-key-entries (merge classes syntax printer))
         merged2 (serialize-style-maps merged)]
+    ;; (?pp 'base (-> base :classes :label))
+    ;; (?pp 'theme (-> theme))
+    ;; (?pp classes)
     {:with-style-maps            merged
      :with-serialized-style-maps (assoc
                                   merged2
@@ -486,59 +524,54 @@
 ;;         ]
 ;;     (?pp :bgc bgc)))
 
+(defn valid-user-theme [theme*]
+  (when (map? theme*) 
+    (if (s/valid? ::theme/theme theme*)
+      theme*
+      (messaging/bad-option-value-warning
+       (let [m (:theme config/options)]
+         (merge m
+                {:k      :theme
+                 :v      theme*
+                 :header (str "[fireworks.core/_p]."
+                              "Problem with the supplied Fireworks theme \""
+                              (:name theme*)
+                              "\":")}))))))
 
 (defn merged-theme*
   ([]
    (merged-theme* nil))
   ([reset]
-   ;; TODO - Add observability for theme, user-config.
-   ;; from env-vars, parsed and validated.
-   (let [theme*           (:theme @config)
-
+   (let [theme*           (:theme @config) ;; TODO - should this be user-config?
          fallback-theme   themes/universal-neutral
-
-         valid-user-theme (when (map? theme*) 
-                            (if (s/valid? ::theme/theme theme*)
-                              theme*
-                              (messaging/bad-option-value-warning
-                               (let [m (:theme config/options)]
-                                 (merge m
-                                        {:k      :theme
-                                         :v      theme*
-                                         :header (str "[fireworks.core/_p]."
-                                                      "Problem with the supplied Fireworks theme \""
-                                                      (:name theme*)
-                                                      "\":")})))))
-
+         user-theme       (valid-user-theme theme*)
          theme            (cond
                             (string? theme*)
                             (get basethemes/stock-themes theme*)
-                            valid-user-theme
-                            valid-user-theme
+                            user-theme
+                            user-theme
                             :else
                             fallback-theme)
-
          mood             (if (dark? (:mood theme))
                             :dark
                             :light)     
-
          base-theme       (if (= mood :dark)
                             basethemes/base-theme-dark*
                             basethemes/base-theme-light*)
-
          rainbow-brackets (rainbow-brackets mood theme)
-
         ;;  metadata-bgcs    (metadata-bgcs mood theme base-theme)
-         
          base-theme       (assoc base-theme :rainbow-brackets rainbow-brackets)
-
          ret              (merge-theme+ base-theme theme)]
-
      ;; TODO - Add observability for theme
      ret)))
 
 
-;; The merged theme to use for printing --------------------------------
+
+
+;; -----------------------------------------------------------------------------
+;; The merged-theme to use for printing, defs inside let form
+;; -----------------------------------------------------------------------------
+
 (let [{:keys [with-style-maps
               with-serialized-style-maps
               err
@@ -568,12 +601,20 @@
           (atom with-style-maps)))))
 
 
-;; Helpers for css -----------------------------------------------------
+
+;; -----------------------------------------------------------------------------
+;; Helpers for css 
+;; -----------------------------------------------------------------------------
+
 (defn line-height-css []
   (str "line-height:" (:line-height @config) ";"))
 
 
-;; Helpers for highlighting --------------------------------------------
+
+;; -----------------------------------------------------------------------------
+;; Helpers for highlighting
+;; -----------------------------------------------------------------------------
+
 (defn highlight-style* [{:keys [style pred]}]
   (let [css-str (if style 
                   (let [style (sanitize-style-map style)]

--- a/src/fireworks/truncate.cljc
+++ b/src/fireworks/truncate.cljc
@@ -79,7 +79,8 @@
    coll-limit
    map-like?
    array-map?
-   depth]
+   depth
+   coll-size]
   (let [;; First we need to check if collection is both not map-like and 
         ;; comprised only of map entries. If this is the case it is most likely
         ;; the result of something like `(into [] {:a "a" :b "b"})`, and we need
@@ -101,7 +102,7 @@
                             {:depth                 (inc depth)
                              :map-entry-in-non-map? all-map-entries?})))]
     (if map-like?
-      (seq->sorted-map ret array-map?)
+      (if (zero? coll-size) ret (seq->sorted-map ret array-map?))
       ret)))
 
 
@@ -134,13 +135,14 @@
            depth
            map-like?
            too-deep?
-           dom-node-type]
+           dom-node-type
+           coll-size]
     :as opts+}]
   (let [coll-limit (if too-deep? 0 (:coll-limit @state/config))
         array-map? (and map-like? (contains? (:all-tags opts+) :array-map))]
     #?(:cljs
        (if (satisfies? ISeqable x)
-         (truncate-iterable x coll-limit map-like? array-map? depth)
+         (truncate-iterable x coll-limit map-like? array-map? depth coll-size)
          (if dom-node-type
            (truncate {:depth (inc depth)} (dom-el-attrs-map x))
            (do 
@@ -150,7 +152,7 @@
                   (map (partial truncate {:depth (inc depth)}))
                   (into {})))))
        :clj
-       (truncate-iterable x coll-limit map-like? array-map? depth))))
+       (truncate-iterable x coll-limit map-like? array-map? depth coll-size))))
 
 
 (defn- user-meta* [x]

--- a/test/fireworks/core_test.cljc
+++ b/test/fireworks/core_test.cljc
@@ -100,33 +100,34 @@
        (deftest p-data-basic-samples
          (is (= 
               (let [ret              (? :data {:label                        "my-label"
-                                              :enable-terminal-truecolor?   true
-                                              :enable-terminal-italics?     true
-                                              :bracket-contrast             "high"
-                                              :theme                        theme
-                                              :custom-printers              {}
-                                              :coll-limit                   20
-                                              :non-coll-length-limit        (-> fireworks.config/options
-                                                                                :non-coll-length-limit
-                                                                                :default)
-                                              :display-namespaces?          (-> fireworks.config/options
-                                                                                :display-namespaces?
-                                                                                :default)
-                                              :metadata-position            (-> fireworks.config/options
-                                                                                :metadata-position
-                                                                                :default)
-                                              :metadata-print-level         (-> fireworks.config/options
-                                                                                :metadata-print-level
-                                                                                :default)
-                                              :non-coll-mapkey-length-limit (-> fireworks.config/options
-                                                                                :non-coll-mapkey-length-limit
-                                                                                :default)}
-                                             smoke-test/basic-samples-cljc)
+                                               :enable-terminal-truecolor?   true
+                                               :enable-terminal-italics?     true
+                                               :bracket-contrast             "high"
+                                               :theme                        theme
+                                               :custom-printers              {}
+                                               :coll-limit                   20
+                                               :non-coll-length-limit        (-> fireworks.config/options
+                                                                                 :non-coll-length-limit
+                                                                                 :default)
+                                               :display-namespaces?          (-> fireworks.config/options
+                                                                                 :display-namespaces?
+                                                                                 :default)
+                                               :metadata-position            (-> fireworks.config/options
+                                                                                 :metadata-position
+                                                                                 :default)
+                                               :metadata-print-level         (-> fireworks.config/options
+                                                                                 :metadata-print-level
+                                                                                 :default)
+                                               :non-coll-mapkey-length-limit (-> fireworks.config/options
+                                                                                 :non-coll-mapkey-length-limit
+                                                                                 :default)}
+                                        smoke-test/basic-samples-cljc)
                     formatted-string (-> ret :formatted :string)]
                 ;; (pp/pprint 'p-data-basic-samples)
                 ;; (pp/pprint formatted-string)
                 formatted-string)
-                "%c{%c%c:abcdefg%c %c{%c%c:boolean%c            %ctrue%c\n           %c:brackets%c           %c[%c%c[%c%c[%c%c[%c%c[%c%c[%c%c]%c%c]%c%c]%c%c]%c%c]%c%c]%c\n           %c:fn%c                 %ccljs.core/juxt%c%c[var_args]%c\n           %c:lamda%c              %cλ%c%c%c%c[%1]%c\n           %c:number%c             %c1234%c\n           %c:record%c             %cFoos%c\n                               %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c\n           %c:regex%c              %c#\"^hi$\"%c\n           %c:string%c             %c\"string\"%c\n           %c:symbol%c             %cmysym%c %c    %c%c^{%c%c:foo%c %c:bar%c%c}%c\n           %c:symbol2%c            %cmysym%c %c    %c%c^{%c%c:foo%c %c[%c%c\"afasdfasf\"%c%c\n                                                 %c%c\"afasdfasf\"%c%c\n                                                 %c%c{%c%c:a%c %c\"foo\"%c%c %c%c:b%c %c[%c%c1%c%c %c%c2%c%c %c%c[%c%c1%c%c %c%c2%c%c %c%c3%c%c %c%c4%c%c]%c%c]%c%c}%c%c\n                                                 %c%c\"afasdfasf\"%c%c\n                                                 %c%c\"afasdfasf\"%c%c]%c%c\n                                           %c%c:bar%c %c\"fooz\"%c%c}%c\n           %c:uuid%c               %c#uuid %c%c\"4fe5d828-6444-11e8-822\"%c...%c%c\n           %c:atom/number%c        %cAtom<%c%c1%c%c>%c\n           %c:atom/record%c        %cAtom<%c%cFoos%c\n                               %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c\n           %c:map/multi-line%c     %c{%c%c:abc%c%c\n                                %c%c\"bar\"%c%c\n                                \n                                %c%c\"asdfasdfa\"%c%c\n                                %c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                \n                                %c%c[%c%c:a%c %c:b%c%c]%c%c\n                                %c%c123444%c%c}%c\n           %c:map/nested-meta%c    %c{%c %c    %c%c^{%c%c:a%c %cfoo%c %c    %c%c^{%c%c:abc%c %cbar%c%c\n                                                    %c%c:xyz%c %c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c}%c%c}%c%c\n                                %c%ca%c %c    %c%c^{%c%c:abc%c %c\"bar\"%c%c %c%c:xyz%c %c\"abc\"%c%c}%c%c\n                                %c%cfoo%c %c    %c%c^{%c%c:abc%c %c\"bar\"%c%c %c%c:xyz%c %c\"abc\"%c%c}%c%c\n                                \n                                %c%c:b%c%c\n                                %c%c2%c%c}%c\n           %c:map/single-line%c    %c{%c%c:a%c %c1%c %c:b%c %c2%c %c:c%c %c\"three\"%c%c}%c\n           %c:set/multi-line%c     %c#{%c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                 %c%c3333333%c%c\n                                 %c%c:22222%c%c}%c\n           %c:set/single-line%c    %c#{%c%c1%c %c\"three\"%c %c:2%c%c}%c\n           %c:vector/multi-line%c  %c[%c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                %c%c:22222%c%c\n                                %c%c3333333%c%c]%c\n           %c:vector/single-line%c %c[%c%c1%c %c:2%c %c\"three\"%c%c]%c%c}%c%c}%c")))
+              "%c{%c%c:abcdefg%c %c{%c%c:boolean%c            %ctrue%c\n           %c:brackets%c           %c[%c%c[%c%c[%c%c[%c%c[%c%c[%c%c]%c%c]%c%c]%c%c]%c%c]%c%c]%c\n           %c:fn%c                 %ccljs.core/juxt%c%c[var_args]%c\n           %c:lamda%c              %cλ%c%c%c%c[%1]%c\n           %c:number%c             %c1234%c\n           %c:record%c             %cFoos%c\n                               %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c\n           %c:regex%c              %c#\"^hi$\"%c\n           %c:string%c             %c\"string\"%c\n           %c:symbol%c             %cmysym%c %c    %c%c^{%c%c:foo%c %c:bar%c%c}%c\n           %c:symbol2%c            %cmysym%c %c    %c%c^{%c%c:foo%c %c[%c%c\"afasdfasf\"%c%c\n                                                 %c%c\"afasdfasf\"%c%c\n                                                 %c%c{%c%c:a%c %c\"foo\"%c%c %c%c:b%c %c[%c%c1%c%c %c%c2%c%c %c%c[%c%c1%c%c %c%c2%c%c %c%c3%c%c %c%c4%c%c]%c%c]%c%c}%c%c\n                                                 %c%c\"afasdfasf\"%c%c\n                                                 %c%c\"afasdfasf\"%c%c]%c%c\n                                           %c%c:bar%c %c\"fooz\"%c%c}%c\n           %c:uuid%c               %c#uuid %c%c\"4fe5d828-6444-11e8-822\"%c...%c%c\n           %c:atom/number%c        %cAtom<%c%c1%c%c>%c\n           %c:atom/record%c        %cAtom<%c%cFoos%c\n                               %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c\n           %c:map/multi-line%c     %c{%c%c:abc%c%c\n                                %c%c\"bar\"%c%c\n                                \n                                %c%c\"asdfasdfa\"%c%c\n                                %c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                \n                                %c%c[%c%c:a%c %c:b%c%c]%c%c\n                                %c%c123444%c%c}%c\n           %c:map/nested-meta%c    %c{%c %c    %c%c^{%c%c:a%c %cfoo%c %c    %c%c^{%c%c:abc%c %cbar%c%c\n                                                    %c%c:xyz%c %c\"abcdefghijklmnopqrstuvwxyzzzz\"%c...%c%c%c}%c%c}%c%c\n                                %c%ca%c %c    %c%c^{%c%c:abc%c %c\"bar\"%c%c %c%c:xyz%c %c\"abc\"%c%c}%c%c\n                                %c%cfoo%c %c    %c%c^{%c%c:abc%c %c\"bar\"%c%c %c%c:xyz%c %c\"abc\"%c%c}%c%c\n                                \n                                %c%c:b%c%c\n                                %c%c2%c%c}%c\n           %c:map/single-line%c    %c{%c%c:a%c %c1%c %c:b%c %c2%c %c:c%c %c\"three\"%c%c}%c\n           %c:set/multi-line%c     %c#{%c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                 %c%c3333333%c%c\n                                 %c%c:22222%c%c}%c\n           %c:set/single-line%c    %c#{%c%c1%c %c\"three\"%c %c:2%c%c}%c\n           %c:vector/multi-line%c  %c[%c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                %c%c:22222%c%c\n                                %c%c3333333%c%c]%c\n           %c:vector/single-line%c %c[%c%c1%c %c:2%c %c\"three\"%c%c]%c%c}%c%c}%c"
+              )))
        
        (deftest p-data-with-coll-limit
          (is (= 
@@ -186,11 +187,11 @@
        (deftest p-data-record-sample-in-atom
          (is (= 
               (let [ret              (? :data {:label                      "my-label"
-                                              :enable-terminal-truecolor? true
-                                              :enable-terminal-italics?   true
-                                              :bracket-contrast           "high"
-                                              :theme                      theme}
-                                             (atom smoke-test/record-sample))
+                                               :enable-terminal-truecolor? true
+                                               :enable-terminal-italics?   true
+                                               :bracket-contrast           "high"
+                                               :theme                      theme}
+                                        (atom smoke-test/record-sample))
                     formatted-string (-> ret :formatted :string)]
                 ;; (pp/pprint 'p-data-record-sample-in-atom)
                 ;; (pp/pprint formatted-string)
@@ -531,7 +532,7 @@
               "〠38;2;190;85;187;48;2;250;232;253〠"
               "^{"
               "〠0〠"
-              "〠38;2;190;85;187;1;48;2;250;232;253〠"
+              "〠38;2;190;85;187;48;2;250;232;253〠"
               ":foo"
               "〠0〠"
               "〠38;2;190;85;187;48;2;250;232;253〠"
@@ -560,35 +561,16 @@
 
 ;; Basic print-and-return tests, cljc
 (do
-  (deftest p-basic
-    (is (= (? {:a   "foo"
-               :xyz "bar"})
-           {:a   "foo"
-            :xyz "bar"})))
-
-  (deftest ?-basic
-    (is (= (? {:a   "foo"
-               :xyz "bar"})
-           {:a   "foo"
-            :xyz "bar"})))
-
-  (deftest !?-basic
-    (is (= (!? {:a   "foo"
-                :xyz "bar"})
-           {:a   "foo"
-            :xyz "bar"})))
-
-  (deftest ?>-basic
-    (is (= (?> {:a   "foo"
-                :xyz "bar"})
-           {:a   "foo"
-            :xyz "bar"})))
-
-  (deftest !?>-basic
-    (is (= (!?> {:a   "foo"
-                 :xyz "bar"})
-           {:a   "foo"
-            :xyz "bar"}))))
+  (deftest ?-par-result
+    (is (= (? :result "par?") "par?")))
+  (deftest ?-par
+    (is (= (? "par?") "par?")))
+  (deftest !?-par
+    (is (= (!? "par?") "par?")))
+  (deftest ?>-par
+    (is (= (?> "par?") "par?")))
+  (deftest !?>-par
+    (is (= (!?> "par?") "par?"))))
 
 ;; (deftest ^:test-refresh/focus test-addition
 ;;   (is (= 2 (+ 1 1))))
@@ -598,4 +580,9 @@
 ;; :single-line-coll-length-limit option 
 ;; :when pred option for selective printing
 ;; correct order of array map entries
+;; correct margins when using margin options
+;; correct margins when using :result flag
+
 ;; Do an assessment of other things you need to cover with tests
+
+

--- a/test/fireworks/smoke_test.cljc
+++ b/test/fireworks/smoke_test.cljc
@@ -929,7 +929,6 @@
 
 
 
-(+ 1 1)
 
 (def basic-samples 
   {:string   "string"
@@ -949,7 +948,7 @@ basic-samples
 
 ;; (? (meta #'basic-samples))
 
-(map #(* % 33) (range 100))
+;; (map #(* % 33) (range 100))
 
 #_(?sgr (-> (? :data {:label                      "my-label-from-opts"
                     :enable-terminal-truecolor? false
@@ -959,8 +958,8 @@ basic-samples
           :formatted
           :string))
 
-(def themez  "Monokai Light")
-(? #_{:theme themez} record-sample)
+;; (def themez  "Monokai Light")
+;; (? #_{:theme themez} record-sample)
 ;; (? #_{:theme "Monokai Light"} (with-meta 'foo {:a "a"}))
 ;; (? "Fix italics" #_(select-keys (:abcdefg basic-samples-cljc) [:uuid :symbol :symbol2]))
 ;; (? (remove true? [true]))

--- a/test/fireworks/smoke_test.cljc
+++ b/test/fireworks/smoke_test.cljc
@@ -3,7 +3,7 @@
 (ns fireworks.smoke-test
   (:require [fireworks.core :refer [? !? ?> !?>]]
             [fireworks.themes :as themes]
-            [bling.core :refer [callout bling]]
+            [bling.core :refer [callout bling ?sgr]]
             [clojure.string :as string]
             [fireworks.pp :as pp]
             [clojure.pprint :refer [pprint]]
@@ -12,6 +12,8 @@
             [lasertag.core :refer [tag-map]]
             #?(:cljs [cljs.test :refer [deftest is]])
             #?(:clj [clojure.test :refer :all])))
+
+(def theme themes/alabaster-light)
 
 ;; testing label length
 ;; (? (str "asdfasdfasdfasdfadsfasfasdf" "zzzzzzzzzzzzz" "xxxxxxx"))
@@ -228,20 +230,6 @@
                             {:abc (symbol "bar")
                              :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})})})
 
-(def basic-samples 
-  {:string   "string"
-   :uuid     #uuid "4fe5d828-6444-11e8-8222-720007e40350"
-   :number   1234
-   :boolean  true
-   :lamda    #(inc %)
-   :fn       juxt
-   :regex    #"^hi$"
-   :record   record-sample
-   :atom2    (atom record-sample)
-   :atom1    (atom 1)
-   :brackets [[[[[[]]]]]]})
-
-(? #_{:theme "Universal Neutral"} basic-samples-cljc-theme)
 
 ;; (?
 ;;  "Nested metadata, on val"
@@ -924,3 +912,110 @@
 ;;          {:a                "foo"
 ;;           :xyz              "bar" 
 ;;           "hi there everyone" #uuid "97bda55b-6175-4c39-9e04-7c0205c709dc"})))
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+(+ 1 1)
+
+(def basic-samples 
+  {:string   "string"
+   :uuid     #uuid "4fe5d828-6444-11e8-8222-720007e40350"
+   :number   1234
+   :boolean  true
+   :lamda    #(inc %)
+   :fn       juxt
+   :regex    #"^hi$"
+   :record   record-sample
+   :atom2    (atom record-sample)
+   :atom1    (atom 1)
+   :brackets [[[[[[]]]]]]})
+
+
+basic-samples
+
+;; (? (meta #'basic-samples))
+
+(map #(* % 33) (range 100))
+
+#_(?sgr (-> (? :data {:label                      "my-label-from-opts"
+                    :enable-terminal-truecolor? false
+                    :enable-terminal-italics?   false
+                    :theme                      theme}
+             "foo")
+          :formatted
+          :string))
+
+(def themez  "Monokai Light")
+(? #_{:theme themez} record-sample)
+;; (? #_{:theme "Monokai Light"} (with-meta 'foo {:a "a"}))
+;; (? "Fix italics" #_(select-keys (:abcdefg basic-samples-cljc) [:uuid :symbol :symbol2]))
+;; (? (remove true? [true]))
+;; (? :pp (select-keys {:a 1 :b 2} [:f :g :c]))
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/visual_test/src/visual_testing/shared.cljc
+++ b/visual_test/src/visual_testing/shared.cljc
@@ -28,7 +28,55 @@
   ;;                            :xyz "abcdefghijklmnop"})})
    })
 
+(def basic-samples-cljc 
+  {:abcdefg {:string             "string"
+             :uuid               #uuid "4fe5d828-6444-11e8-8222-720007e40350"
+             :number             1234
+             :symbol             (with-meta 'mysym {:foo :bar})
+             :symbol2            (with-meta 'mysym
+                                   {:foo ["afasdfasf"
+                                          "afasdfasf"
+                                          {:a "foo"
+                                           :b [1 2 [1 2 3 4]]}
+                                          "afasdfasf"
+                                          "afasdfasf"]
+
+                                    :bar "fooz"})
+             :boolean            true
+             :lamda              #(inc %)
+             :fn                 juxt
+             :regex              #"^hi$"
+             :record             record-sample
+             :atom/record        (atom record-sample)
+             :atom/number        (atom 1)
+             :brackets           [[[[[[]]]]]]
+             :map/nested-meta    (with-meta 
+                                   {(with-meta (symbol :a)
+                                      {:abc "bar"
+                                       :xyz "abc"}) (with-meta (symbol "foo")
+                                                      {:abc "bar"
+                                                       :xyz "abc"})
+                                    :b                                               2}
+                                   {:a (with-meta (symbol "foo")
+                                         {:abc (symbol "bar")
+                                          :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})})
+             :map/single-line    {:a 1
+                                  :b 2
+                                  :c "three"}
+             :map/multi-line     {:abc      "bar"
+                                  "asdfasdfa" "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
+                                  [:a :b]   123444}
+             :vector/single-line [1 :2 "three"]
+             :vector/multi-line  ["abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
+                                  :22222
+                                  3333333]
+             :set/single-line    #{1 :2 "three"}
+             :set/multi-line     #{"abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
+                                   :22222
+                                   3333333}}})
+
 (defn test-suite []
+  (? {:coll-limit 30} basic-samples-cljc)
   (? foo)
   (? :default foo)
   (? {:theme "Alabaster Light"


### PR DESCRIPTION
#### Fixes
- Fixes empty map bug

#### Added
- Exposes `:margin-top` and `:margin-bottom` options

#### Changed
- Increase depth of caught-exception (in `fireworks.core/formatted`) stack trace preview to 12 frames
