### PR TITLE
Volatiles and transients

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,13 +748,13 @@ The simplest way to make a theme is to just start experimenting within any names
 
 ;; And then just try it out with some kind of sample value like this:
 (? {:theme my-theme}
-   {:string-sample  "string"
-    :number-sample  1234
-    :boolean-sample true
-    :lamda-sample   #(inc %)
-    :fn-sample      juxt
-    :regex-sample   #"^hi$"
-    :symbol-sample  'mysym})
+   {:string-sample   "string"
+    :number-sample   1234
+    :boolean-sample  true
+    :labmda-sample   #(inc %)
+    :fn-sample       juxt
+    :regex-sample    #"^hi$"
+    :symbol-sample   'mysym})
 ```
 
 Tweak the colors to your liking, save the theme as an `.edn` file somewhere on your computer, then set that path as the value of the `:theme` entry in your `.edn` config.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.paintparty/fireworks "0.9.0"
+(defproject io.github.paintparty/fireworks "0.10.0"
   :description "Themeable print debugging library for Clojure, ClojureScript, and Babashka"
   :url "https://github.com/paintparty/fireworks"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
@@ -6,7 +6,7 @@
   :source-paths ["src"
                 ;;  for local dev
                 ;;  "../bling/src"
-                ;;  "../lasertag/src"
+                 "../lasertag/src"
                  ]
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [expound "0.9.0"]

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :source-paths ["src"
                 ;;  for local dev
                 ;;  "../bling/src"
-                 "../lasertag/src"
+                ;;  "../lasertag/src"
                  ]
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [expound "0.9.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.paintparty/fireworks "0.10.0"
+(defproject io.github.paintparty/fireworks "0.10.0-SNAPSHOT"
   :description "Themeable print debugging library for Clojure, ClojureScript, and Babashka"
   :url "https://github.com/paintparty/fireworks"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/fireworks/brackets.cljc
+++ b/src/fireworks/brackets.cljc
@@ -35,7 +35,7 @@
     (= t :meta-map)
     ["^{" "}"]
 
-    (or (= :function t) (= :lamda t))
+    (or (= :function t) (= :lambda t))
     ["" ""]
     :else
         ;; This should probably be ["" ""]
@@ -192,12 +192,15 @@
     ob))
 
 (defn closing-angle-bracket! 
-  "This is for when collections are also like atoms,
-   so they can be printed like `Atom<[1 2 3]>`"
+  "This is for when collections are encapsulated in a mutable construct such as
+   an atom or volatile, so they can be printed like `Atom<[1 2 3]>`"
   [m]
-  (when (-> m :coll meta :atom?)
-    (when (state/debug-tagging?)
-      (println "\ntagging " defs/encapsulation-closing-bracket " with " :atom-wrapper))
-    (str (tag! :atom-wrapper)
-         defs/encapsulation-closing-bracket
-         (tag-reset!))))
+  ;; TODO - change names to avoid shadowing
+  (let [{:keys [val-is-atom? val-is-volatile?]} (-> m :coll meta)]
+    (when (or val-is-atom? val-is-volatile?)
+      (let [k (if val-is-atom? :atom-wrapper :volatile-wrapper)]
+        (when (state/debug-tagging?)
+          (println "\ntagging " defs/encapsulation-closing-bracket " with " k))
+        (str (tag! k)
+             defs/encapsulation-closing-bracket
+             (tag-reset!))))))

--- a/src/fireworks/brackets.cljc
+++ b/src/fireworks/brackets.cljc
@@ -43,27 +43,6 @@
         ;; :list-like? :array-like?
     ["[" "]"]))
 
-
-(def num-indent-spaces
-  (reduce (fn [acc k] 
-            (assoc acc
-                   k 
-                   (-> {:t k}
-                       brackets-by-type
-                       first
-                       count)))
-          {}
-          [:meta-map
-           :map       
-           :js/Object 
-           :js/Array  
-           :record    
-           :set       
-           :js/Set    
-           :vector    
-           :list      
-           :seq]))
-
 (defn- rainbow-bracket-color
   []
   (let [rb           (:rainbow-brackets @state/merged-theme) 

--- a/src/fireworks/core.cljc
+++ b/src/fireworks/core.cljc
@@ -173,6 +173,9 @@
           ;; TODO - is the space before the newline necessary ?
           (tag/tag-entity! " \n" :result-header))
 
+        css-count*
+        (count @state/styles)
+
         fmt           
         (when-not (or log?
                       threading?
@@ -207,7 +210,8 @@
 
      {:fmt        fmt
       :fmt+       fmt+
-      :file-info* file-info*}))
+      :file-info* file-info*
+      :css-count* css-count*}))
 
 
 (defn- margin-block-str
@@ -277,7 +281,7 @@
                  (or mll?
                      (< 44 (count (str label))))))
 
-        {:keys [fmt+ fmt file-info*]}
+        {:keys [fmt+ fmt file-info* css-count*]}
         (fmt+ (keyed [file-info-first? 
                       user-print-fn
                       threading?
@@ -301,7 +305,7 @@
         :formatted  (merge {:string fmt}
                            #?(:cljs {:css-styles (subvec
                                                   @state/styles 
-                                                  (count @state/styles))}))})
+                                                  css-count*)}))})
 
       ;; Else if print-and-return fns, return printing opts
       {:fmt           fmt+

--- a/src/fireworks/defs.cljc
+++ b/src/fireworks/defs.cljc
@@ -74,8 +74,10 @@
    :function-args         :bracket
    :literal-label         :label
    :type-label            :label
-   :lamda-label           :label
+   :lambda-label           :label
+   :mutable-wrapper       :label
    :atom-wrapper          :label
+   :volatile-wrapper      :label
    :metadata              :metadata
    :metadata2             :metadata2
    :metadata-key          :metadata
@@ -155,16 +157,26 @@
 
 (def volatile-label "Volatile")
 
+(def transient-label "Transient")
+
 (def encapsulation-opening-bracket "<")
 
 (def encapsulation-closing-bracket ">")
 
-(def atom-wrap-count
-  (count (str atom-label
-              encapsulation-opening-bracket
-              encapsulation-closing-bracket)))
+(defn- mutable-wrap-count
+  "Counts the label plus opening and closing encapsulation brackets.
+   Example:
+   (mutable-wrap-count \"Atom\") ; => 6"
+  [s]
+  (count (str s encapsulation-opening-bracket encapsulation-closing-bracket)))
 
-(def lamda-symbol "λ")
+(def atom-wrap-count
+  (mutable-wrap-count atom-label))
+
+(def volatile-wrap-count
+  (mutable-wrap-count volatile-label))
+
+(def lambda-symbol "λ")
 
 (def js-literal-badge "#js ")
 
@@ -180,4 +192,4 @@
 (def js-map-arrow "->")
 
 (def inline-badges
-  #{js-literal-badge inst-badge uuid-badge lamda-symbol})
+  #{js-literal-badge inst-badge uuid-badge lambda-symbol})

--- a/src/fireworks/serialize.cljc
+++ b/src/fireworks/serialize.cljc
@@ -424,21 +424,12 @@
                       (or str-len-with-badge 0))))))
 
         ;; This is where indenting for multi-line collections is determined
-        t-for-indent
-        (cond
-          user-meta-map?
-          :meta-map
-          (or record? js-map-like? map-like?)
-          :map
-          :else
-          t) 
-
         num-indent-spaces-for-t
-        (t-for-indent brackets/num-indent-spaces)
+        (if (or set-like? user-meta-map? (= t :js/Set)) 2 1)
 
         indent       
         (+ (or indent* 0)
-           (or num-indent-spaces-for-t 1))
+           num-indent-spaces-for-t)
 
         badge-above?
         (some->> badge (contains? defs/inline-badges) not)

--- a/src/fireworks/serialize.cljc
+++ b/src/fireworks/serialize.cljc
@@ -3,7 +3,6 @@
    [clojure.walk :as walk]
    [fireworks.profile :as profile]
    [fireworks.truncate :as truncate]
-   [fireworks.pp :refer [?pp !?pp]]
    [fireworks.brackets
     :as brackets
     :refer [closing-bracket! 
@@ -79,7 +78,6 @@
            t
            key?
            sev?
-           atom?
            badge
            indent
            fn-args
@@ -87,10 +85,12 @@
            separator
            max-keylen
            multi-line?
+           val-is-atom?
            number-type?
            highlighting
            :fw/user-meta
            fn-display-name
+           val-is-volatile?
            js-map-like-key?
            num-chars-dropped
            str-len-with-badge
@@ -99,6 +99,12 @@
     :as m}]
   (let [encapsulated?
         (or (= t :uuid) (contains? all-tags :inst))
+
+        mutable-tagging-opts
+        (when (or val-is-atom? val-is-volatile?)
+          {:theme-token  (if val-is-atom? :atom-wrapper :volatile-wrapper)
+           :display?     true
+           :highlighting highlighting})
 
         ;; State mutation start  ---------------------------------------------
         
@@ -133,11 +139,9 @@
                                spaces))))
 
         atom-tagged
-        (tagged (str defs/atom-label
-                     defs/encapsulation-opening-bracket) 
-                {:theme-token  :atom-wrapper
-                 :display?     atom?
-                 :highlighting highlighting})
+        (some->> mutable-tagging-opts
+                 (tagged (str (if val-is-volatile? defs/volatile-label defs/atom-label)
+                              defs/encapsulation-opening-bracket)))
 
         badge-tagged
         (tagged badge
@@ -145,8 +149,8 @@
                  :theme-token        (cond
                                        (pos? (state/formatting-meta-level))
                                        (state/metadata-token)
-                                       (= badge defs/lamda-symbol) 
-                                       :lamda-label 
+                                       (= badge defs/lambda-symbol) 
+                                       :lambda-label 
                                        :else
                                        :literal-label)})
 
@@ -170,7 +174,6 @@
                 (if l2? :metadata2 :metadata)))
             theme-tag))
 
-
         _ 
         (when (state/debug-tagging?)
             (println "\nsev!   tagging " s " with " theme-tag))
@@ -192,10 +195,9 @@
         (tagged fn-args {:theme-token :function-args})
 
         atom-closing-bracket-tagged
-        (tagged defs/encapsulation-closing-bracket
-                {:theme-token  :atom-wrapper 
-                 :display?     atom?
-                 :highlighting highlighting})
+
+        (some->> mutable-tagging-opts 
+                 (tagged defs/encapsulation-closing-bracket))
 
         user-meta-inline-tagged
         (when (sev-user-meta-position-match? user-meta :inline)
@@ -203,13 +205,15 @@
           (let [offset        defs/metadata-position-inline-offset
                 inline-offset (tagged (spaces (dec offset))
                                       {:theme-token (state/metadata-token)})
-                ret           (formatted* user-meta
-                                          {:indent     (+ indent
-                                                          offset
-                                                          (or str-len-with-badge
-                                                              0))
-                                           :user-meta? true})]
+                ret           (formatted*
+                               user-meta
+                               {:indent     (+ indent
+                                               offset
+                                               (or ellipsized-char-count 0))
+                                :user-meta? true})]
             (swap! state/*formatting-meta-level dec)
+            ;; TODO - figure out how to create left arrow char with foreground
+            ;; color of metadata background.
             (str " " inline-offset ret)))
 
         ;; Atom mutation end  ------------------------------------------------
@@ -380,7 +384,6 @@
        seq
        boolean))
 
-
 (defn- reduce-coll-profile
   [coll indent*]
   (let [{:keys [some-elements-carry-user-metadata?  
@@ -388,15 +391,16 @@
                 :fw/custom-badge-style
                 str-len-with-badge
                 :fw/user-meta-map?
+                val-is-volatile?
                 :fw/user-meta
-                js-map-like?
-                num-dropped         
+                js-map-like?         
+                val-is-atom?
+                num-dropped
                 too-deep?
-                map-like?
+                set-like?
                 record?
                 badge
                 depth
-                atom?
                 t]
          :as   meta-map}
         (meta coll)
@@ -449,8 +453,10 @@
             indent)
 
         ;; Add support for volatile! encapsulation
-        indent (if (and atom? (not badge-above?))
-                 (+ (or (count (str defs/atom-label
+        indent (if (and (or val-is-atom? val-is-volatile?) (not badge-above?))
+                 (+ (or (count (str (if val-is-atom?
+                                      defs/atom-label
+                                      defs/volatile-label)
                                     defs/encapsulation-opening-bracket))
                         0)
                     indent)
@@ -485,17 +491,18 @@
                 annotation-newline 
                 metadata-position
                 user-meta-above?
+                val-is-volatile?
                 let-bindings?
+                val-is-atom?   
                 num-dropped
-                multi-line?   
+                multi-line?
                 coll-count
                 separator
                 user-meta
                 too-deep?
                 record?
                 indent
-                badge
-                atom?])]
+                badge])]
       ret))
 
 
@@ -514,7 +521,7 @@
 (defn- user-meta-inline
   [{:keys [user-meta
            metadata-position
-           atom-opening-encapsulation
+           mutable-opening-encapsulation
            badge
            coll
            indent*]}]
@@ -530,7 +537,7 @@
                           {:user-meta?
                            true
                            :indent 
-                           (let [ob (str atom-opening-encapsulation
+                           (let [ob (str mutable-opening-encapsulation
                                          badge
                                          (some-> coll
                                                  meta
@@ -545,22 +552,24 @@
 
 (defn- profile+ob
   [coll indent*]
-  (let [{:keys [atom?
-                badge
+  (let [{:keys [badge
                 record?
                 user-meta
                 separator
+                val-is-atom?
                 let-bindings?
+                val-is-volatile?
                 annotation-newline
                 custom-badge-style]
          :as m} 
         (reduce-coll-profile coll indent*)
-        ;; Atom-wrapper opening made here
-        atom-opening-encapsulation
-        (when atom? 
-          (tagged (str defs/atom-label
+
+        ;; Mutable-wrapper opening made here
+        mutable-opening-encapsulation
+        (when (or val-is-atom? val-is-volatile?) 
+          (tagged (str (if val-is-atom? defs/atom-label defs/volatile-label)
                        defs/encapsulation-opening-bracket) 
-                  {:theme-token :atom-wrapper}))
+                  {:theme-token (if val-is-atom? :atom-wrapper :volatile-wrapper)}))
 
         ;; Block-level badges for colls (display above coll) are made here
         badge               
@@ -580,7 +589,7 @@
         (user-meta-block indent* metadata-position m)
 
         ob* 
-        (str atom-opening-encapsulation
+        (str mutable-opening-encapsulation
              badge
              (some-> user-meta-block (str (when badge " ")))
              annotation-newline
@@ -589,7 +598,7 @@
                (tagged "#" {:theme-token :max-print-level-label})))
         
         user-meta-inline
-        (user-meta-inline (keyed [atom-opening-encapsulation
+        (user-meta-inline (keyed [mutable-opening-encapsulation
                                   metadata-position
                                   user-meta
                                   indent*
@@ -813,7 +822,8 @@
            indent
            multi-line?
            separator
-           max-keylen]}]
+           max-keylen]
+    :as m}]
   (let [t                          
         (or t (:t val-props))
 
@@ -867,20 +877,23 @@
    ;; Just for debugging
    ;;  #?(:cljs (js/console.clear))
    
-   (let [truncated      (truncate/truncate {:depth      0
-                                            :user-meta? user-meta?}
-                                           source)
-         custom-printed truncated
+   (let [truncated  (truncate/truncate {:depth      0
+                                        :user-meta? user-meta?}
+                                       source)
+        ;;  custom-printed truncated
          ;; TODO - revisit this custom printing stuff
          ;; custom-printed (if (:evaled-form? opts)
          ;;                  truncated
          ;;                  (walk/postwalk printers/custom truncated))
-         profiled       (walk/prewalk profile/profile custom-printed)
-         serialized     (serialized profiled indent)
-         len            (-> profiled meta :str-len-with-badge)
+         profiled   (walk/prewalk profile/profile truncated)
+         serialized (serialized profiled indent)
+        ;;  len            (-> profiled meta :str-len-with-badge)
          ]
 
     ;; Just for debugging
+    ;;  (when (:coll-type? (meta profiled))
+    ;;      (?pp (meta profiled)))
+    ;; (?pp (meta profiled))
     ;;  (?pp (map 
     ;;        (fn [a b]
     ;;          [a b])

--- a/src/fireworks/state.cljc
+++ b/src/fireworks/state.cljc
@@ -18,7 +18,6 @@
             [fireworks.util :as util]))
 
 ;; Internal state atoms for development debugging ------------------------
-
 (def debug-config? false)
 (def print-config? false)
 

--- a/src/fireworks/themes.cljc
+++ b/src/fireworks/themes.cljc
@@ -64,26 +64,26 @@
    :author "Author Name"
    :langs  ["Clojure" "ClojureScript" "Babashka"]
    :mood   :light
-   :tokens {:classes {:background    {:background-color "#f7f7f7"}
-                      :string        {:color "#448C27"}
-                      :constant      {:color "#7A3E9D"}
-                      :definition    {:color "#4d6dba"}
-                      :annotation    {:color      "#8c8c8c" 
-                                      :font-style :italic}
-                      :metadata      {:color            "#be55bb"
-                                      :text-shadow      "0 0 2px #ffffff"
-                                      :background-color "#fae8fd"}
-                      :metadata2     {:color            "#9f60be"
-                                      :text-shadow      "0 0 2px #ffffff"
-                                      :background-color "#e9e5ff"}
-                      :label         {:color            "#4d6dba"
-                                      :background-color "#edf2fc"
-                                      :text-shadow      "0 0 2px #ffffff"
-                                      :font-style       :italic}
-                      :eval-label    {:color            "#4d6dba"
-                                      :background-color "#edf2fc"
-                                      :text-shadow      "0 0 2px #ffffff"
-                                      :font-style       :italic}}
+   :tokens {:classes {:background {:background-color "#f7f7f7"}
+                      :string     {:color "#448C27"}
+                      :constant   {:color "#7A3E9D"}
+                      :definition {:color "#4d6dba"}
+                      :annotation {:color      "#8c8c8c" 
+                                   :font-style :italic}
+                      :metadata   {:color            "#be55bb"
+                                   :text-shadow      "0 0 2px #ffffff"
+                                   :background-color "#fae8fd"}
+                      :metadata2  {:color            "#9f60be"
+                                   :text-shadow      "0 0 2px #ffffff"
+                                   :background-color "#e9e5ff"}
+                      :label      {:color            "#398962"
+                                   :background-color "#eefbee"
+                                   :text-shadow      "0 0 2px #ffffff"
+                                   :font-style       :italic}
+                      :eval-label {:color            "#4d6dba"
+                                   :background-color "#edf2fc"
+                                   :text-shadow      "0 0 2px #ffffff"
+                                   :font-style       :italic}}
             :syntax  {:js-object-key {:color "#888888"}}
             :printer {:file-info     {:color                "#4d6dba"
                                       :font-style           :italic

--- a/test/fireworks/core_test.cljc
+++ b/test/fireworks/core_test.cljc
@@ -22,7 +22,7 @@
           (let [ret (? :data {:theme theme} "foo")] #_(pp/pprint "p-data basic") #_(pp/pprint ret) ret)
           {:quoted-form   "foo",
            :formatted     {:string     "%c\"foo\"%c"
-                           :css-styles []},
+                           :css-styles ["color:#448C27;line-height:1.45;" "color:#585858;line-height:1.45;"]},
            :file          "fireworks/core_test.cljc",
            :end-column    51,
            :ns-str        "fireworks.core-test",
@@ -45,7 +45,7 @@
           (let [ret (? :data "my-label" "foo")] #_(pp/pprint "p-data-with-label") #_(pp/pprint ret) ret)
           {:quoted-form   "foo",
            :formatted     {:string     "%c\"foo\"%c"
-                           :css-styles []},
+                           :css-styles ["color:#448C27;line-height:1.45;" "color:#585858;line-height:1.45;"]},
            :file          "fireworks/core_test.cljc",
            :end-column    47,
            :ns-str        "fireworks.core-test",
@@ -64,7 +64,6 @@
                                         "color:#585858;line-height:1.45;"]}}))))
 
 
-
 #?(:cljs
    (do (deftest p-data-with-label-from-opts
          (is (= 
@@ -78,16 +77,17 @@
                 ;; (pp/pprint ret)
                 ret)
               {:quoted-form   "foo",
-               :formatted     {:string     "%c\"foo\"%c"
-                               :css-styles []},
+               :formatted     {:string     "%c\"foo\"%c",
+                               :css-styles ["color:#448C27;line-height:1.45;"
+                                            "color:#585858;line-height:1.45;"]},
                :file          "fireworks/core_test.cljc",
                :end-column    34,
                :ns-str        "fireworks.core-test",
-               :file-info-str "fireworks.core-test:71:25",
+               :file-info-str "fireworks.core-test:70:25",
                :column        25,
-               :line          71,
-               :end-line      76,
-               :formatted+    {:string     "%cmy-label-from-opts%c  %cfireworks.core-test:71:25%c%c \n%c%c\"foo\"%c",
+               :line          70,
+               :end-line      75,
+               :formatted+    {:string     "%cmy-label-from-opts%c  %cfireworks.core-test:70:25%c%c \n%c%c\"foo\"%c",
                                :css-styles ["color:#4d6dba;background-color:#edf2fc;text-shadow:0 0 2px #ffffff;font-style:italic;line-height:1.45;"
                                             "color:#585858;line-height:1.45;"
                                             "color:#4d6dba;font-style:italic;padding-inline-start:0ch;line-height:1.45;"
@@ -126,17 +126,17 @@
                 ;; (pp/pprint 'p-data-basic-samples)
                 ;; (pp/pprint formatted-string)
                 formatted-string)
-               "%c{%c%c:abcdefg%c %c{%c%c:boolean%c            %ctrue%c\n           %c:brackets%c           %c[%c%c[%c%c[%c%c[%c%c[%c%c[%c%c]%c%c]%c%c]%c%c]%c%c]%c%c]%c\n           %c:fn%c                 %ccljs.core/juxt%c%c[var_args]%c\n           %c:lamda%c              %cλ%c%c%c%c[%1]%c\n           %c:number%c             %c1234%c\n           %c:record%c             %cFoos%c\n                               %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c\n           %c:regex%c              %c#\"^hi$\"%c\n           %c:string%c             %c\"string\"%c\n           %c:symbol%c             %cmysym%c %c    %c%c^{%c%c:foo%c %c:bar%c%c}%c\n           %c:symbol2%c            %cmysym%c %c    %c%c^{%c%c:foo%c %c[%c%c\"afasdfasf\"%c%c\n                                                 %c%c\"afasdfasf\"%c%c\n                                                 %c%c{%c%c:a%c %c\"foo\"%c%c %c%c:b%c %c[%c%c1%c%c %c%c2%c%c %c%c[%c%c1%c%c %c%c2%c%c %c%c3%c%c %c%c4%c%c]%c%c]%c%c}%c%c\n                                                 %c%c\"afasdfasf\"%c%c\n                                                 %c%c\"afasdfasf\"%c%c]%c%c\n                                           %c%c:bar%c %c\"fooz\"%c%c}%c\n           %c:uuid%c               %c#uuid %c%c\"4fe5d828-6444-11e8-822\"%c...%c%c\n           %c:atom/number%c        %cAtom<%c%c1%c%c>%c\n           %c:atom/record%c        %cAtom<%c%cFoos%c\n                               %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c\n           %c:map/multi-line%c     %c{%c%c:abc%c%c\n                                %c%c\"bar\"%c%c\n                                \n                                %c%c\"asdfasdfa\"%c%c\n                                %c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                \n                                %c%c[%c%c:a%c %c:b%c%c]%c%c\n                                %c%c123444%c%c}%c\n           %c:map/nested-meta%c    %c{%c %c    %c%c^{%c%c:a%c %cfoo%c %c    %c%c^{%c%c:abc%c %cbar%c%c\n                                                    %c%c:xyz%c %c\"abcdefghijklmnopqrstuvwxyzzzz\"%c...%c%c%c}%c%c}%c%c\n                                %c%ca%c %c    %c%c^{%c%c:abc%c %c\"bar\"%c%c %c%c:xyz%c %c\"abc\"%c%c}%c%c\n                                %c%cfoo%c %c    %c%c^{%c%c:abc%c %c\"bar\"%c%c %c%c:xyz%c %c\"abc\"%c%c}%c%c\n                                \n                                %c%c:b%c%c\n                                %c%c2%c%c}%c\n           %c:map/single-line%c    %c{%c%c:a%c %c1%c %c:b%c %c2%c %c:c%c %c\"three\"%c%c}%c\n           %c:set/multi-line%c     %c[%c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                %c%c3333333%c%c\n                                %c%c:22222%c%c]%c\n           %c:set/single-line%c    %c[%c%c1%c %c\"three\"%c %c:2%c%c]%c\n           %c:vector/multi-line%c  %c[%c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                %c%c:22222%c%c\n                                %c%c3333333%c%c]%c\n           %c:vector/single-line%c %c[%c%c1%c %c:2%c %c\"three\"%c%c]%c%c}%c%c}%c"
+              "%c{%c%c:abcdefg%c %c{%c%c:boolean%c            %ctrue%c\n           %c:brackets%c           %c[%c%c[%c%c[%c%c[%c%c[%c%c[%c%c]%c%c]%c%c]%c%c]%c%c]%c%c]%c\n           %c:fn%c                 %ccljs.core/juxt%c%c[var_args]%c\n           %c:lambda%c             %c%c%c[%1]%c\n           %c:number%c             %c1234%c\n           %c:record%c             %cFoos%c\n                               %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c\n           %c:regex%c              %c#\"^hi$\"%c\n           %c:string%c             %c\"string\"%c\n           %c:symbol%c             %cmysym%c %c    %c%c^{%c%c:foo%c %c:bar%c%c}%c\n           %c:symbol2%c            %cmysym%c %c    %c%c^{%c%c:foo%c %c[%c%c\"afasdfasf\"%c%c\n                                                 %c%c\"afasdfasf\"%c%c\n                                                 %c%c{%c%c:a%c %c\"foo\"%c%c %c%c:b%c %c[%c%c1%c%c %c%c2%c%c %c%c[%c%c1%c%c %c%c2%c%c %c%c3%c%c %c%c4%c%c]%c%c]%c%c}%c%c\n                                                 %c%c\"afasdfasf\"%c%c\n                                                 %c%c\"afasdfasf\"%c%c]%c%c\n                                           %c%c:bar%c %c\"fooz\"%c%c}%c\n           %c:uuid%c               %c#uuid %c%c\"4fe5d828-6444-11e8-822\"%c...%c%c\n           %c:atom/number%c        %cAtom<%c%c1%c%c>%c\n           %c:atom/record%c        %cAtom<%c%cFoos%c\n                               %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c\n           %c:map/multi-line%c     %c{%c%c:abc%c%c\n                                %c%c\"bar\"%c%c\n                                \n                                %c%c\"asdfasdfa\"%c%c\n                                %c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                \n                                %c%c[%c%c:a%c %c:b%c%c]%c%c\n                                %c%c123444%c%c}%c\n           %c:map/nested-meta%c    %c{%c %c    %c%c^{%c%c:a%c %cfoo%c %c    %c%c^{%c%c:abc%c %cbar%c%c\n                                                    %c%c:xyz%c %c\"abcdefghijklmnopqrstuvwxyzzzz\"%c...%c%c%c}%c%c}%c%c\n                                %c%ca%c %c    %c%c^{%c%c:abc%c %c\"bar\"%c%c %c%c:xyz%c %c\"abc\"%c%c}%c%c\n                                %c%cfoo%c %c    %c%c^{%c%c:abc%c %c\"bar\"%c%c %c%c:xyz%c %c\"abc\"%c%c}%c%c\n                                \n                                %c%c:b%c%c\n                                %c%c2%c%c}%c\n           %c:map/single-line%c    %c{%c%c:a%c %c1%c %c:b%c %c2%c %c:c%c %c\"three\"%c%c}%c\n           %c:set/multi-line%c     %c[%c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                %c%c3333333%c%c\n                                %c%c:22222%c%c]%c\n           %c:set/single-line%c    %c[%c%c1%c %c\"three\"%c %c:2%c%c]%c\n           %c:vector/multi-line%c  %c[%c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                %c%c:22222%c%c\n                                %c%c3333333%c%c]%c\n           %c:vector/single-line%c %c[%c%c1%c %c:2%c %c\"three\"%c%c]%c%c}%c%c}%c"
               )))
        
        (deftest p-data-with-coll-limit
          (is (= 
               (let [ret              (? :data {:label                      "my-label"
-                                              :enable-terminal-truecolor? true
-                                              :enable-terminal-italics?   true
-                                              :coll-limit                 5
-                                              :theme                      theme}
-                                             [1 2 3 4 5 6 7 8])
+                                               :enable-terminal-truecolor? true
+                                               :enable-terminal-italics?   true
+                                               :coll-limit                 5
+                                               :theme                      theme}
+                                        [1 2 3 4 5 6 7 8])
                     formatted-string (-> ret :formatted :string)]
                 ;; (pp/pprint formatted-string)
                 formatted-string)
@@ -145,12 +145,12 @@
        (deftest p-data-with-non-coll-level-1-depth-length-limit
          (is (= 
               (let [ret              (? :data {:label                         "my-label"
-                                          :enable-terminal-truecolor?    true
-                                          :enable-terminal-italics?      true
-                                          :bracket-contrast              "high"
-                                          :theme                         theme
-                                          :non-coll-depth-1-length-limit 60}
-                                         ["asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas"])
+                                               :enable-terminal-truecolor?    true
+                                               :enable-terminal-italics?      true
+                                               :bracket-contrast              "high"
+                                               :theme                         theme
+                                               :non-coll-depth-1-length-limit 60}
+                                        ["asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas"])
                     formatted-string (-> ret :formatted :string)]
                 ;; (pp/pprint formatted-string)
                 formatted-string)
@@ -159,12 +159,12 @@
        (deftest p-data-with-non-coll-length-limit
          (is (= 
               (let [ret              (? :data {:label                        "my-label"
-                                              :enable-terminal-truecolor?   true
-                                              :enable-terminal-italics?     true
-                                              :bracket-contrast             "high"
-                                              :theme                        theme
-                                              :non-coll-result-length-limit 42}
-                                             "asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas")
+                                               :enable-terminal-truecolor?   true
+                                               :enable-terminal-italics?     true
+                                               :bracket-contrast             "high"
+                                               :theme                        theme
+                                               :non-coll-result-length-limit 42}
+                                        "asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas")
                     formatted-string (-> ret :formatted :string)]
                 ;; (pp/pprint 'p-data-with-non-coll-length-limit)
                 ;; (pp/pprint formatted-string)
@@ -174,11 +174,11 @@
        (deftest p-data-rainbow-brackets
          (is (= 
               (let [ret              (? :data {:label                      "my-label"
-                                              :enable-terminal-truecolor? true
-                                              :enable-terminal-italics?   true
-                                              :bracket-contrast           "high"
-                                              :theme                      theme}
-                                         [[[[[]]]]])
+                                               :enable-terminal-truecolor? true
+                                               :enable-terminal-italics?   true
+                                               :bracket-contrast           "high"
+                                               :theme                      theme}
+                                        [[[[[]]]]])
                     formatted-string (-> ret :formatted :string)]
                 ;; (pp/pprint formatted-string)
                 formatted-string)
@@ -203,37 +203,75 @@
        (deftest p-data-js-array
          (is (= 
               (let [ret              (? :data {:label                      "my-label"
-                                              :enable-terminal-truecolor? true
-                                              :enable-terminal-italics?   true
-                                              :bracket-contrast           "high"
-                                              :theme                      theme}
-                                             #js [1 2 3])
+                                               :enable-terminal-truecolor? true
+                                               :enable-terminal-italics?   true
+                                               :bracket-contrast           "high"
+                                               :theme                      theme}
+                                        #js [1 2 3])
                     formatted-string (-> ret :formatted :string)]
                 ;; (pp/pprint 'p-data-js-array)
                 ;; (pp/pprint formatted-string)
                 formatted-string)
-             nil)))
+              nil)))
+       
+       (deftest p-data-record-sample-in-volatile
+         (is (= 
+              (let [ret              (? :data {:label                      "my-label"
+                                               :enable-terminal-truecolor? true
+                                               :enable-terminal-italics?   true
+                                               :bracket-contrast           "high"
+                                               :theme                      theme}
+                                        (volatile! smoke-test/record-sample))
+                    formatted-string (-> ret :formatted :string)]
+                ;; (pp/pprint 'p-data-record-sample-in-volatile)
+                ;; (pp/pprint formatted-string)
+                formatted-string)
+              "%cVolatile<%c%cFoos%c\n%c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c")))
+
+       
+
+       ;; Leave this out until you figure out what is going on with transients in node-based testing
+       #_(deftest transient-vector
+           (is (= 
+                (let [ret              (let [x   (transient [1 2 3 4 5 6 7 8 9 0])
+                                             ret (? :data {:coll-limit                 7
+                                                           :label                      "my-label"
+                                                           :enable-terminal-truecolor? true
+                                                           :enable-terminal-italics?   true
+                                                           :bracket-contrast           "high"
+                                                           :theme                      theme}
+                                                    x)]
+                                         (conj! x 5)
+                                         ret)
+
+                      _                (do (println "FUUUU")
+                                           (pp/pprint ret))
+                      formatted-string (-> ret :formatted :string)]
+                  (pp/pprint ret)
+                  (pp/pprint 'transient-vector)
+                  (pp/pprint formatted-string)
+                  formatted-string)
+                "%cVolatile<%c%cFoos%c\n%c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c")))
 
 
        ;; Leave this out until you support custom printers 
        #_(deftest p-data-custom-printers
-         (is (= 
-              (let [ret              
-                    (p-data {:custom-printers {:vector {:pred        (fn [x] (= x [1 2 3 4]))
-                                                    :f           (fn [x] (into #{} x))
-                                                    :badge-text  " Set💩 "
-                                                    :badge-style {:color            "#000"
-                                                                  :background-color "lime"
-                                                                  :border-radius    "999px"
-                                                                  :text-shadow      "none"
-                                                                  :font-style       "normal"}}}}
-                        [1 2 3 4])
-                    formatted-string (-> ret :formatted :string)]
-                (pp/pprint formatted-string)
-                formatted-string)
-              "%c Set💩 %c
+           (is (= 
+                (let [ret              (p-data {:custom-printers {:vector {:pred        (fn [x] (= x [1 2 3 4]))
+                                                                           :f           (fn [x] (into #{} x))
+                                                                           :badge-text  " Set💩 "
+                                                                           :badge-style {:color            "#000"
+                                                                                         :background-color "lime"
+                                                                                         :border-radius    "999px"
+                                                                                         :text-shadow      "none"
+                                                                                         :font-style       "normal"}}}}
+                                               [1 2 3 4])
+                      formatted-string (-> ret :formatted :string)]
+                  (pp/pprint formatted-string)
+                  formatted-string)
+                "%c Set💩 %c
 %c#{%c%c1%c %c2%c %c3%c %c4%c%c}%c")))
-)
+       )
    
    :clj
    #_nil
@@ -252,10 +290,10 @@
      (deftest p-data-with-label-from-opts-primitive-terminal-emulator
        (is (= 
             (let [ret              (? :data {:label                      "my-label-from-opts"
-                                            :enable-terminal-truecolor? false
-                                            :enable-terminal-italics?   false
-                                            :theme                      theme}
-                                           "foo")
+                                             :enable-terminal-truecolor? false
+                                             :enable-terminal-italics?   false
+                                             :theme                      theme}
+                                      "foo")
                   formatted-string (-> ret :formatted :string)]
               ;; (pp/pprint (escape-sgr formatted-string))
               (escape-sgr formatted-string))
@@ -264,12 +302,12 @@
      (deftest p-data-with-non-coll-level-1-depth-length-limit
        (is (= 
             (let [ret              (? :data {:label                         "my-label"
-                                            :enable-terminal-truecolor?    true
-                                            :enable-terminal-italics?      true
-                                            :bracket-contrast              "high"
-                                            :theme                         theme
-                                            :non-coll-depth-1-length-limit 60}
-                                           ["asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas"])
+                                             :enable-terminal-truecolor?    true
+                                             :enable-terminal-italics?      true
+                                             :bracket-contrast              "high"
+                                             :theme                         theme
+                                             :non-coll-depth-1-length-limit 60}
+                                      ["asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas"])
                   formatted-string (-> ret :formatted :string)]
               (escape-sgr formatted-string))
             '("〠38;5;241〠"
@@ -288,12 +326,12 @@
      (deftest p-data-with-non-coll-result-length-limit
        (is (= 
             (let [ret              (? :data {:label                        "my-label"
-                                            :enable-terminal-truecolor?   true
-                                            :enable-terminal-italics?     true
-                                            :bracket-contrast             "high"
-                                            :theme                        theme
-                                            :non-coll-result-length-limit 42}
-                                           "asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas")
+                                             :enable-terminal-truecolor?   true
+                                             :enable-terminal-italics?     true
+                                             :bracket-contrast             "high"
+                                             :theme                        theme
+                                             :non-coll-result-length-limit 42}
+                                      "asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas")
                   formatted-string (-> ret :formatted :string)]
               ;; (pp/pprint 'p-data-with-non-coll-result-length-limit)
               ;; (pp/pprint (escape-sgr formatted-string))
@@ -305,12 +343,12 @@
      (deftest p-data-with-coll-limit
        (is (= 
             (let [ret              (? :data {:label                      "my-label"
-                                            :enable-terminal-truecolor? true
-                                            :enable-terminal-italics?   true
-                                            :coll-limit                 5
-                                            :theme                      theme
-                                            :custom-printers            {}}
-                                           [1 2 3 4 5 6 7 8])
+                                             :enable-terminal-truecolor? true
+                                             :enable-terminal-italics?   true
+                                             :coll-limit                 5
+                                             :theme                      theme
+                                             :custom-printers            {}}
+                                      [1 2 3 4 5 6 7 8])
                   formatted-string (-> ret :formatted :string)]
               ;; (pp/pprint (escape-sgr formatted-string))
               (escape-sgr formatted-string))
@@ -346,11 +384,11 @@
      (deftest p-data-rainbow-brackets
        (is (= 
             (let [ret              (? :data {:label                      "my-label"
-                                            :enable-terminal-truecolor? true
-                                            :enable-terminal-italics?   true
-                                            :bracket-contrast           "high"
-                                            :theme                      theme}
-                                           [[[[[]]]]])
+                                             :enable-terminal-truecolor? true
+                                             :enable-terminal-italics?   true
+                                             :bracket-contrast           "high"
+                                             :theme                      theme}
+                                      [[[[[]]]]])
                   formatted-string (-> ret :formatted :string)]
               ;; (pp/pprint (escape-sgr formatted-string))
               (escape-sgr formatted-string))
@@ -388,11 +426,11 @@
      (deftest p-data-rainbow-brackets-low-contrast
        (is (= 
             (let [ret              (? :data {:label                      "my-label"
-                                            :enable-terminal-truecolor? true
-                                            :enable-terminal-italics?   true
-                                            :bracket-contrast           "low"
-                                            :theme                      theme}
-                                           [[[[[]]]]])
+                                             :enable-terminal-truecolor? true
+                                             :enable-terminal-italics?   true
+                                             :bracket-contrast           "low"
+                                             :theme                      theme}
+                                      [[[[[]]]]])
                   formatted-string (-> ret :formatted :string)]
               ;; (pp/pprint (escape-sgr formatted-string))
               (escape-sgr formatted-string))
@@ -440,14 +478,14 @@
               ;; (pp/pprint 'p-data-record-sample-in-atom)
               ;; (pp/pprint (escape-sgr formatted-string))
               (escape-sgr formatted-string))
-            '("〠3;38;2;77;109;186;48;2;237;242;252〠"
+            '("〠3;38;2;57;137;98;48;2;238;251;238〠"
               "Atom<"
               "〠0〠"
-              "〠3;38;2;77;109;186;48;2;237;242;252〠"
+              "〠3;38;2;57;137;98;48;2;238;251;238〠"
               "Foos"
               "〠0〠"
               "\n"
-              "〠38;5;241;48;2;237;242;252〠"
+              "〠38;5;241;48;2;238;251;238〠"
               "{"
               "〠0〠"
               "〠38;2;122;62;157〠"
@@ -465,10 +503,10 @@
               "〠38;2;122;62;157〠"
               "2"
               "〠0〠"
-              "〠38;5;241;48;2;237;242;252〠"
+              "〠38;5;241;48;2;238;251;238〠"
               "}"
               "〠0〠"
-              "〠3;38;2;77;109;186;48;2;237;242;252〠"
+              "〠3;38;2;57;137;98;48;2;238;251;238〠"
               ">"
               "〠0〠"))))
 
@@ -484,11 +522,11 @@
               ;; (pp/pprint 'p-data-record-sample)
               ;; (pp/pprint (escape-sgr formatted-string))
               (escape-sgr formatted-string))
-            '("〠3;38;2;77;109;186;48;2;237;242;252〠"
+            '("〠3;38;2;57;137;98;48;2;238;251;238〠"
               "Foos"
               "〠0〠"
               "\n"
-              "〠38;5;241;48;2;237;242;252〠"
+              "〠38;5;241;48;2;238;251;238〠"
               "{"
               "〠0〠"
               "〠38;2;122;62;157〠"
@@ -506,18 +544,18 @@
               "〠38;2;122;62;157〠"
               "2"
               "〠0〠"
-              "〠38;5;241;48;2;237;242;252〠"
+              "〠38;5;241;48;2;238;251;238〠"
               "}"
               "〠0〠"))))
 
      (deftest p-data-symbol-with-meta
        (is (= 
             (let [ret              (? :data {:label                      "my-label"
-                                            :enable-terminal-truecolor? true
-                                            :enable-terminal-italics?   true
-                                            :bracket-contrast           "high"
-                                            :theme                      theme}
-                                           (with-meta 'mysym {:foo :bar}))
+                                             :enable-terminal-truecolor? true
+                                             :enable-terminal-italics?   true
+                                             :bracket-contrast           "high"
+                                             :theme                      theme}
+                                      (with-meta 'mysym {:foo :bar}))
                   formatted-string (-> ret :formatted :string)]
               ;; (pp/pprint 'p-data-symbol-with-meta)
               ;; (pp/pprint (escape-sgr formatted-string))
@@ -543,6 +581,583 @@
               "〠0〠"
               "〠38;2;190;85;187;48;2;250;232;253〠"
               "}"
+              "〠0〠"))))
+
+     (deftest transient-vector
+       (is (= 
+            (let [ret              (let [x   (transient [1 2 3 4 5 6 7 8 9 0])
+                                         ret (? :data {:coll-limit                 7
+                                                       :label                      "my-label"
+                                                       :enable-terminal-truecolor? true
+                                                       :enable-terminal-italics?   true
+                                                       :bracket-contrast           "high"
+                                                       :theme                      theme}
+                                                x)]
+                                     (conj! x 5)
+                                     ret)
+                  formatted-string (-> ret :formatted :string)]
+              ;; (pp/pprint 'transient-vector)
+              ;; (pp/pprint (escape-sgr formatted-string))
+              (escape-sgr formatted-string))
+            '("〠3;38;2;57;137;98;48;2;238;251;238〠"
+              "TransientVector"
+              "〠0〠"
+              "\n"
+              "〠38;5;241;48;2;238;251;238〠"
+              "["
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "1"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "2"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "3"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "4"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "5"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "6"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "7"
+              "〠0〠"
+              "〠3;38;2;140;140;140〠"
+              " ...+3"
+              "〠0〠"
+              "〠38;5;241;48;2;238;251;238〠"
+              "]"
+              "〠0〠"))))
+     
+     (deftest transient-set
+       (is (= 
+            (let [ret              (let [x   (transient #{:a 1
+                                                          :b 2
+                                                          :c 3
+                                                          :d 4
+                                                          :e 5
+                                                          :f 6
+                                                          :g 7
+                                                          :h 8
+                                                          :i 9
+                                                          :j 10 })
+                                         ret (? :data {:coll-limit                 7
+                                                       :label                      "my-label"
+                                                       :enable-terminal-truecolor? true
+                                                       :enable-terminal-italics?   true
+                                                       :bracket-contrast           "high"
+                                                       :theme                      theme}
+                                                x)]
+                                     (conj! x 11)
+                                     ret)
+                  formatted-string (-> ret :formatted :string)]
+              ;; (pp/pprint 'transient-set)
+              ;; (pp/pprint (escape-sgr formatted-string))
+              (escape-sgr formatted-string))
+            '("〠3;38;2;57;137;98;48;2;238;251;238〠"
+              "TransientHashSet"
+              "〠0〠"
+              "\n"
+              "〠38;5;241;48;2;238;251;238〠"
+              "#{"
+              "〠0〠"
+              "〠3;38;2;140;140;140〠"
+              "...+20"
+              "〠0〠"
+              "〠38;5;241;48;2;238;251;238〠"
+              "}"
+              "〠0〠"))))
+     
+     (deftest transient-map
+       (is (= 
+            (let [ret              (let [x   (transient {:a 1
+                                                         :b 2
+                                                         :c 3
+                                                         :d 4
+                                                         :e 5
+                                                         :f 6
+                                                         :g 7
+                                                         :h 8
+                                                         :i 9
+                                                         :j 10 })
+                                         ret (? :data {:coll-limit                 7
+                                                       :label                      "my-label"
+                                                       :enable-terminal-truecolor? true
+                                                       :enable-terminal-italics?   true
+                                                       :bracket-contrast           "high"
+                                                       :theme                      theme}
+                                                x)]
+                                     (assoc! x :k 11)
+                                     ret)
+                  formatted-string (-> ret :formatted :string)]
+              ;; (pp/pprint 'transient-set)
+              ;; (pp/pprint (escape-sgr formatted-string))
+              (escape-sgr formatted-string))
+            '("〠3;38;2;57;137;98;48;2;238;251;238〠"
+              "TransientHashMap"
+              "〠0〠"
+              "\n"
+              "〠38;5;241;48;2;238;251;238〠"
+              "{"
+              "〠0〠"
+              "〠3;38;2;140;140;140〠"
+              " ......+10"
+              "〠0〠"
+              "〠38;5;241;48;2;238;251;238〠"
+              "}"
+              "〠0〠"))))
+     
+     (deftest array-map-order
+       (is (= 
+            (let [ret              (? :data 
+                                      {:enable-terminal-truecolor? true
+                                       :enable-terminal-italics?   true
+                                       :bracket-contrast           "high"
+                                       :theme                      theme}
+                                      (array-map :a 1 :b 2 :c 3 :d 4 :e 5 :f 6 :g 7 :h 8 :i 9 :j 10))
+                  formatted-string (-> ret :formatted :string)]
+              ;; (pp/pprint 'array-map-order)
+              ;; (pp/pprint (escape-sgr formatted-string))
+              (escape-sgr formatted-string))
+            '("〠38;5;241〠"
+              "{"
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              ":a"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "1"
+              "〠0〠"
+              "\n "
+              "〠38;2;122;62;157〠"
+              ":b"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "2"
+              "〠0〠"
+              "\n "
+              "〠38;2;122;62;157〠"
+              ":c"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "3"
+              "〠0〠"
+              "\n "
+              "〠38;2;122;62;157〠"
+              ":d"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "4"
+              "〠0〠"
+              "\n "
+              "〠38;2;122;62;157〠"
+              ":e"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "5"
+              "〠0〠"
+              "\n "
+              "〠38;2;122;62;157〠"
+              ":f"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "6"
+              "〠0〠"
+              "\n "
+              "〠38;2;122;62;157〠"
+              ":g"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "7"
+              "〠0〠"
+              "\n "
+              "〠38;2;122;62;157〠"
+              ":h"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "8"
+              "〠0〠"
+              "\n "
+              "〠38;2;122;62;157〠"
+              ":i"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "9"
+              "〠0〠"
+              "\n "
+              "〠38;2;122;62;157〠"
+              ":j"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "10"
+              "〠0〠"
+              "〠38;5;241〠"
+              "}"
+              "〠0〠"))))
+     
+     (deftest single-line-coll-length-limit-50-19
+       (is (= 
+            (let [ret              (? :data 
+                                      {:enable-terminal-truecolor?    true
+                                       :enable-terminal-italics?      true
+                                       :bracket-contrast              "high"
+                                       :single-line-coll-length-limit 50
+                                       :theme                         theme}
+                                      (range 19))
+                  formatted-string (-> ret :formatted :string)]
+              ;; (pp/pprint 'single-line-coll-length-limit-50-19)
+              ;; (pp/pprint (escape-sgr formatted-string))
+              (escape-sgr formatted-string))
+            '("〠38;5;241〠"
+              "("
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "0"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "1"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "2"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "3"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "4"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "5"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "6"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "7"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "8"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "9"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "10"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "11"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "12"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "13"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "14"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "15"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "16"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "17"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "18"
+              "〠0〠"
+              "〠38;5;241〠"
+              ")"
+              "〠0〠"))))
+     
+     (deftest single-line-coll-length-limit-50-20
+       (is (= 
+            (let [ret              (? :data 
+                                      {:enable-terminal-truecolor?    true
+                                       :enable-terminal-italics?      true
+                                       :bracket-contrast              "high"
+                                       :single-line-coll-length-limit 50
+                                       :theme                         theme}
+                                      (range 20))
+                  formatted-string (-> ret :formatted :string)]
+              ;; (pp/pprint 'array-map-order)
+              ;; (pp/pprint (escape-sgr formatted-string))
+              (escape-sgr formatted-string))
+            '("〠38;5;241〠"
+              "("
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "0"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "1"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "2"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "3"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "4"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "5"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "6"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "7"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "8"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "9"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "10"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "11"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "12"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "13"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "14"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "15"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "16"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "17"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "18"
+              "〠0〠"
+              "〠38;2;88;88;88〠"
+              "\n "
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "19"
+              "〠0〠"
+              "〠38;5;241〠"
+              ")"
+              "〠0〠"))))
+
+     (deftest java-util-hashset
+       (is (= 
+            (let [ret              (? :data 
+                                      {:enable-terminal-truecolor? true
+                                       :enable-terminal-italics?   true
+                                       :bracket-contrast           "high"
+                                       :theme                      theme}
+                                      (java.util.HashSet. #{"a" 1
+                                                            "b" 2}))
+                  formatted-string (-> ret :formatted :string)]
+              ;; (pp/pprint 'java-util-hashset)
+              ;; (pp/pprint (escape-sgr formatted-string))
+              (escape-sgr formatted-string))
+            '("〠3;38;2;57;137;98;48;2;238;251;238〠"
+              "java.util.HashSet"
+              "〠0〠"
+              "\n"
+              "〠38;5;241;48;2;238;251;238〠"
+              "#{"
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "1"
+              "〠0〠"
+              " "
+              "〠38;2;68;140;39〠"
+              "\"a\""
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "2"
+              "〠0〠"
+              " "
+              "〠38;2;68;140;39〠"
+              "\"b\""
+              "〠0〠"
+              "〠38;5;241;48;2;238;251;238〠"
+              "}"
+              "〠0〠"))))
+     
+     (deftest java-util-hashmap
+       (is (= 
+            (let [ret              (? :data 
+                                      {:enable-terminal-truecolor? true
+                                       :enable-terminal-italics?   true
+                                       :bracket-contrast           "high"
+                                       :theme                      theme}
+                                      (java.util.HashMap. {"a" 1
+                                                           "b" 2}))
+                  formatted-string (-> ret :formatted :string)]
+              ;; (pp/pprint 'java-util-hashmap)
+              ;; (pp/pprint (escape-sgr formatted-string))
+              (escape-sgr formatted-string))
+            '("〠3;38;2;57;137;98;48;2;238;251;238〠"
+              "java.util.HashMap"
+              "〠0〠"
+              "\n"
+              "〠38;5;241;48;2;238;251;238〠"
+              "{"
+              "〠0〠"
+              "〠38;2;68;140;39〠"
+              "\"a\""
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "1"
+              "〠0〠"
+              " "
+              "〠38;2;68;140;39〠"
+              "\"b\""
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "2"
+              "〠0〠"
+              "〠38;5;241;48;2;238;251;238〠"
+              "}"
+              "〠0〠"))))
+     
+     (deftest java-util-arraylist
+       (is (= 
+            (let [ret              (? :data 
+                                      {:enable-terminal-truecolor? true
+                                       :enable-terminal-italics?   true
+                                       :bracket-contrast           "high"
+                                       :theme                      theme}
+                                      (java.util.ArrayList. [1 2 3]))
+                  formatted-string (-> ret :formatted :string)]
+              ;; (pp/pprint 'java-util-hashmap)
+              ;; (pp/pprint (escape-sgr formatted-string))
+              (escape-sgr formatted-string))
+            '("〠3;38;2;57;137;98;48;2;238;251;238〠"
+              "java.util.ArrayList"
+              "〠0〠"
+              "\n"
+              "〠38;5;241;48;2;238;251;238〠"
+              "["
+              "〠0〠"
+              "〠38;2;122;62;157〠"
+              "1"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "2"
+              "〠0〠"
+              " "
+              "〠38;2;122;62;157〠"
+              "3"
+              "〠0〠"
+              "〠38;5;241;48;2;238;251;238〠"
+              "]"
               "〠0〠"))))))
 
 (defn- escape-sgr
@@ -572,16 +1187,16 @@
   (deftest !?>-par
     (is (= (!?> "par?") "par?"))))
 
+
 ;; (deftest ^:test-refresh/focus test-addition
 ;;   (is (= 2 (+ 1 1))))
 
 
 ;; TODO - Add tests for:
-;; :single-line-coll-length-limit option 
 ;; :when pred option for selective printing
-;; correct order of array map entries
 ;; correct margins when using margin options
 ;; correct margins when using :result flag
 ;; Java Objects from java.util.*
 ;; More native js Objects
-;; Other transient Clojure(Script) types
+
+;; Other transient ClojureScript types (strange in node testing)

--- a/test/fireworks/smoke_test.cljc
+++ b/test/fireworks/smoke_test.cljc
@@ -180,7 +180,7 @@
 
                                     :bar "fooz"})
              :boolean            true
-             :lamda              #(inc %)
+             :lambda              #(inc %)
              :fn                 juxt
              :regex              #"^hi$"
              :record             record-sample
@@ -218,7 +218,7 @@
    :number          1234
    :symbol          (with-meta 'mysym {:foo :bar})
    :boolean         true
-   :lamda           #(inc %)
+   :lambda           #(inc %)
    :fn              juxt
    :regex           #"^hi$"
    :record          record-sample
@@ -935,7 +935,7 @@
    :uuid     #uuid "4fe5d828-6444-11e8-8222-720007e40350"
    :number   1234
    :boolean  true
-   :lamda    #(inc %)
+   :lambda    #(inc %)
    :fn       juxt
    :regex    #"^hi$"
    :record   record-sample
@@ -950,7 +950,7 @@
    :uuid     #uuid "4fe5d828-6444-11e8-8222-720007e40350"
    :number   1234
    :boolean  true
-   :lamda    #(inc %)
+   :lambda    #(inc %)
    :fn       juxt
    :regex    #"^hi$"
    :record   record-sample
@@ -984,97 +984,147 @@ basic-samples
 (!?  #_{} basic-samples-array-map)
 (!?  #_{} basic-samples-cljc)
 (!? {:coll-limit 5} (atom (with-meta (range 8) {:foo :bar})))
-#?(:clj
-   (do 
-     (!? (instance? java.util.AbstractCollection (java.util.HashMap. {"a" 1
-                                                                      "b" 2})))
-    ;;  (? (java.lang.String. "welcome"))
-    ;;  (? "welcome")
-    ;;  (? #{"a" 1 "b" 2})                        
-
-     (!? (java.util.HashSet. #{"a" 1
-                              "b" 2}))
-     (!? (tag (java.util.HashSet. #{"a" 1
-                                   "b" 2})))
-
-     (? (java.util.HashMap. {"a" 1
-                              "b" 2}))
-    ;;  (? (tag (java.util.HashMap. {"a" 1
-    ;;                               "b" 2})))
-    ;;  (? (tag [1 2]))
-    ;;  (? (tag (list 1 2)))
-    ;;  (? (tag '(1 2)))
-    ;;  (? (tag (range 3)))
-    ;;  (? (tag (map inc (range 3))))
-
-    ;;  (!? (java.util.ArrayList. [1 2 3]))
-    ;;  (? (tag (java.util.ArrayList. [1 2 3])))
-    ;;  (? (tag-map (java.util.ArrayList. [1 2 3])))
-    ;;  (? (.isArray (.getClass (java.util.ArrayList. [1 2 3]))))
 
 
-    ;;  (!? (tag (to-array '(1 2 3 4))))
+#_(? :result (atom 1))
+#_(? :result (atom [1 2 3]))
+;; (? :result (atom {1 2 3 4}))
+;; (? (atom "a"))
+#_(? {:ababad [1
+             2
+             (with-meta (symbol "a") {:foo :bar :bang :baz :go :yeah})
+             #_(atom (with-meta (symbol "a") {:foo :bar :bang :baz :go :yeah}))
+             3]})
+;; (? :result [1 2 3 [(atom "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")]])
+;; (? :result (atom (range 35)))
+#_(? :result [1
+            2
+            [(atom xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz)]])
 
-     (? (tag-map (to-array '(1 2 3 4))))
+#_(println "\n\n")
+;; (? :result (volatile! 1))
+;; (? :result (volatile! [1 2 3]))
+;; (? :result (volatile! {1 2 3 4}))
+;; (? :result (volatile! (range 35)))
+;; (? :result (volatile! ^{:foo :bar} [1 2 3]))
 
-    ;;  (println (type (to-array '(1 2 3 4))))
-
-    ;;  (!? (.isArray (.getClass (to-array '(1 2 3 4)))))
-
-     (? (to-array '(1 2 3 4)))
-
-
-     (!? (instance? java.util.ArrayList (java.util.ArrayList. [1 2 3])))
-     (!? (instance? java.util.ArrayList [1 2 3]))))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+;; (? (volatile! "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+;; (? (volatile! "a"))
+;; (? :result [1 2 3 [(volatile! "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")]])
+;; (? :result [1
+;;             2
+;;             [(volatile! xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz)]])
 
 
+;; (pprint (? :data (volatile! record-sample)))
+;; (pprint (? :data (atom record-sample)))
+#?(:cljs
+   ()
+   :clj
+   (do
+     (? (tag-map {:a 1}))
+     #_(? #{"abcdefghijklmnopqrstuvwxyzzz"
+            3333333})
+
+    ;;  (? {:non-coll-length-limit 50} (tag-map (transient [1 2 3 4])))
+     
+     #_(? (transient [1 2 3 4]))
+
+     #_(let [x (transient #{:a 1
+                          :b 2
+                          :c 3
+                          :d 4
+                          :e 5
+                          :f 6
+                          :g 7
+                          :h 8
+                          :i 9
+                          :j 10 })]
+       (? {:coll-limit 7} x)
+       (conj! x 11))
+
+    ;;  (? (lasertag.core/tag-map 1))
+     
+    ;;  (? (transient (into [] (range 333))))
+     
+    ;;  (? (atom (into [] (range 33))))
+     
+    ;;  (? (to-array '(1 2 3 4 5 6 7 8 9 0)))
+     
+    ;;  (? (tag-map (transient [1 2 3 4])))
+    ;;  (? (transient (into #{} (range 100))))
+    ;;  (? (transient {1 2
+    ;;                 3 4}))
+     
+    ;;  (? (type (transient {1   2
+    ;;                       3   4
+    ;;                       5   6
+    ;;                       7   8
+    ;;                       9   10
+    ;;                       11  12
+    ;;                       13  14
+    ;;                       15  16
+    ;;                       17  18
+    ;;                       191 20
+    ;;                       21  22})))
+    ;;  (? (type (transient {1   2
+    ;;                       3   4
+    ;;                       5   6
+    ;;                       7   8
+    ;;                       9   10
+    ;;                       11  12
+    ;;                       13  14
+    ;;                       15  16
+    ;;                       17  18
+    ;;                       191 20
+    ;;                       21  22})))
+     ))
+
+;; #?(:clj
+;;    (do 
+;;      (!? (instance? java.util.AbstractCollection (java.util.HashMap. {"a" 1
+;;                                                                       "b" 2})))
+;;     ;;  (? (java.lang.String. "welcome"))
+;;     ;;  (? "welcome")
+;;     ;;  (? #{"a" 1 "b" 2})                        
 
 
+    ;;  (? (java.util.HashSet. #{"a" 1
+    ;;                           "b" 2}))
+
+;;      (!? (tag (java.util.HashSet. #{"a" 1
+;;                                    "b" 2})))
+
+    ;;  (? (java.util.HashMap. {"a" 1
+    ;;                           "b" 2}))
+;;     ;;  (? (tag (java.util.HashMap. {"a" 1
+;;     ;;                               "b" 2})))
+;;     ;;  (? (tag [1 2]))
+;;     ;;  (? (tag (list 1 2)))
+;;     ;;  (? (tag '(1 2)))
+;;     ;;  (? (tag (range 3)))
+;;     ;;  (? (tag (map inc (range 3))))
+
+    ;;  (? (java.util.ArrayList. [1 2 3]))
+;;     ;;  (? (tag (java.util.ArrayList. [1 2 3])))
+;;     ;;  (? (tag-map (java.util.ArrayList. [1 2 3])))
+;;     ;;  (? (.isArray (.getClass (java.util.ArrayList. [1 2 3]))))
+
+      ;;  (? {:non-coll-length-limit 50} (tag-map (transient [1 2 3])))
+
+;;     ;;  (!? (tag (to-array '(1 2 3 4))))
+
+;;      (? (tag-map (to-array '(1 2 3 4))))
+
+;;     ;;  (println (type (to-array '(1 2 3 4))))
+
+;;     ;;  (!? (.isArray (.getClass (to-array '(1 2 3 4)))))
+
+;;      (? (to-array '(1 2 3 4)))
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+;;      (!? (instance? java.util.ArrayList (java.util.ArrayList. [1 2 3])))
+;;      (!? (instance? java.util.ArrayList [1 2 3]))))
 
 
 

--- a/visual_test/shadow-cljs.edn
+++ b/visual_test/shadow-cljs.edn
@@ -3,8 +3,11 @@
 {:source-paths ["src/"
                 ;; Local Fireworks - uncomment if debugging Fireworks locally
                 ;; "../src/"
+                ;; Local Lasertag - uncomment if debugging Lasertag locally
+                ;; "../../lasertag/src/"
                 ]
- :dependencies [[io.github.paintparty/fireworks "0.9.0-SNAPSHOT"]]
+ :dependencies [[io.github.paintparty/fireworks "0.10.0-SNAPSHOT"]
+                [binaryage/devtools "1.0.6"]]
  :dev-http     {8020 "public"}
  :builds       {:app  {:target           :browser
                        :output-dir       "public/js"

--- a/visual_test/src/visual_testing/shared.cljc
+++ b/visual_test/src/visual_testing/shared.cljc
@@ -3,7 +3,7 @@
   (:require [fireworks.config]
             [fireworks.themes]
             [lasertag.core]
-            [fireworks.core :refer [?]]))
+            [fireworks.core :refer [? pprint]]))
 
 (defrecord Foo [a b])
 
@@ -16,7 +16,7 @@
   ;;  :symbol          (with-meta 'mysym {:foo :bar})
    :symbol        {:foo :bar}
    :boolean       true
-   :lamda         #(inc %)
+   :lambda         #(inc %)
    :fn            juxt
    :regex         #"^hi$"
    :record        record-sample
@@ -47,7 +47,7 @@
 
                                     :bar "fooz"})
              :boolean            true
-             :lamda              #(inc %)
+             :lambda              #(inc %)
              :fn                 juxt
              :regex              #"^hi$"
              :record             record-sample
@@ -80,7 +80,6 @@
                                    3333333}}})
 
 (defn test-suite []
-  (? {:coll-limit 30} basic-samples-cljc)
   (? foo)
   (? :default foo)
   (? {:theme "Alabaster Light"
@@ -126,7 +125,7 @@
 
   (println "\n:single-line-coll-length-limit of 50")
   (? {:single-line-coll-length-limit 50} (range 20))
-  
+
   (? {:label                        "my-label"
       :enable-terminal-truecolor?   true
       :enable-terminal-italics?     true
@@ -169,7 +168,7 @@
 
                                          :bar "fooz"})
                   :boolean            true
-                  :lamda              #(inc %)
+                  :lambda              #(inc %)
                   :fn                 juxt
                   :regex              #"^hi$"
                   :record             record-sample
@@ -202,14 +201,167 @@
                                         3333333}}}
      )
 
-  #?(:cljs
-     (? (lasertag.core/tag (array 1 2 3)))
+  
+  (println "\n:Volatile, record")
+  (? {:label                      "my-label"
+      :enable-terminal-truecolor? true
+      :enable-terminal-italics?   true
+      :bracket-contrast           "high"}
+     (volatile! record-sample))
+
+  (println "\n:Transient Array")
+  (let [x (transient [1 2 3 4 5 6 7 8 9 0])]
+    (? {:coll-limit                 7
+        :label                      "my-label"
+        :enable-terminal-truecolor? true
+        :enable-terminal-italics?   true
+        :bracket-contrast           "high"}
+       x)
+    (conj! x 5)) 
+
+  (println "\n:Transient Map")
+  (let [x (transient {:a 1
+                      :b 2
+                      :c 3
+                      :d 4
+                      :e 5
+                      :f 6
+                      :g 7
+                      :h 8
+                      :i 9
+                      :j 10 })]
+    (? {:coll-limit 7} x)
+    (assoc! x :k 11))
+
+  (println "\n:Transient Set")
+  (let [x (transient #{1 2 3 4 5 6 7 8 9 0})]
+    (? {:label "Transient Set" :coll-limit 7} x)
+    (conj! x 11))
+  nil)
+
+
+
+;; For trying stuff out
+#_(defn test-suite []
+
+  (? {:label                        "my-label"
+      :enable-terminal-truecolor?   true
+      :enable-terminal-italics?     true
+      :bracket-contrast             "high"
+      :custom-printers              {}
+      :coll-limit                   20
+      :non-coll-length-limit        (-> fireworks.config/options
+                                        :non-coll-length-limit
+                                        :default)
+      :display-namespaces?          (-> fireworks.config/options
+                                        :display-namespaces?
+                                        :default)
+      :metadata-position            (-> fireworks.config/options
+                                        :metadata-position
+                                        :default)
+      :metadata-print-level         (-> fireworks.config/options
+                                        :metadata-print-level
+                                        :default)
+      :non-coll-mapkey-length-limit (-> fireworks.config/options
+                                        :non-coll-mapkey-length-limit
+                                        :default)} basic-samples-cljc)
+  ;; (println "v")
+  ;; (pprint (? :data (volatile! record-sample)))
+  
+ #_#?(:cljs
+     (do 
+      ;;  (println "atom")
+      ;;  (pprint (:formatted (? :data (atom record-sample))))
+      ;;  (? (atom record-sample))
+       
+      ;;  (println "\n\n")
+       
+      ;;  (println "Volatile")
+       (pprint (:formatted (? :data 
+                              {:label                      "my-label"
+                               :enable-terminal-truecolor? true
+                               :enable-terminal-italics?   true
+                               :bracket-contrast           "high"}
+                              (volatile! record-sample))))
+      ;;  (? (volatile! record-sample))
+      ;;  (? (lasertag.core/js-object-instance (transient [1 2 3 4])))
+       #_(let [x (transient [1 2 3 4 5 6 7 8 9 0])]
+         (? {:coll-limit                 7
+             :label                      "my-label"
+             :enable-terminal-truecolor? true
+             :enable-terminal-italics?   true
+             :bracket-contrast           "high"}
+          x)
+         #_(pprint (? :data {:coll-limit                 7
+                           :label                      "my-label"
+                           :enable-terminal-truecolor? true
+                           :enable-terminal-italics?   true
+                           :bracket-contrast           "high"}
+                    x))
+         (conj! x 5))
+       
+      ;;  (let [x (transient #{1 2 3 4 5 6 7 8 9 0})]
+      ;;    (? "Transient set" {:coll-limit 7} x)
+      ;;    (conj! x 11))
+       
+       #_(? {})
+
+       #_(let [x (transient {:a 1
+                             :b 2
+                             :c 3
+                             :d 4
+                             :e 5
+                             :f 6
+                             :g 7
+                             :h 8
+                             :i 9
+                             :j 10 })]
+           (? {:coll-limit 7} x)
+           (assoc! x :k 11))
+       
+       #_(? (volatile! record-sample))
+
+       #_(let [x (transient #{:a 1
+                            :b 2
+                            :c 3
+                            :d 4
+                            :e 5
+                            :f 6
+                            :g 7
+                            :h 8
+                            :i 9
+                            :j 10 })]
+         (? {:coll-limit 7} x)
+         (conj! x 11))
+       
+       #_(? (transient {:a 1
+                        :b 2
+                        :c 3
+                        :d 4
+                        :e 5
+                        :f 6
+                        :g 7
+                        :h 8
+                        :i 9
+                        :j 10}))
+      ;;  (? (lasertag.core/tag-map 1))
+      ;;  (js/console.log lasertag.cljs-interop/js-built-in-objects-by-object-map)
+      ;;  (js/console.log lasertag.cljs-interop/js-built-ins-by-category)
+       
+      ;;  (? (lasertag.core/js-object-instance 1))
+       
+      ;;  (? (transient [1 2 3 4]))
+      ;;  (? (type (transient #{1 2 3 4})))
+      ;;  (? (type (transient {1 2 3 4})))
+      ;;  (? (type (transient {1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 191 20 21 22})))
+      ;;  (? (type (transient {1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 191 20 21 22})))
+       
+      ;;  (? (atom record-sample))
+       )
      :clj
-     ())
+     nil)
 
-  nil
-  )
-
+  nil)
 
 
 


### PR DESCRIPTION
Closes #33. Closes #31

Various refactorings and code cleanup.

#### Added
- Support for labeling and printing volatiles
- Support for labeling and printing transient data structures

#### Breaking changes
- Rename `:lamda-label` to `:lambda-label` in theme syntax
