### PR TITLE
Support non-browser envs in ClojureScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@
 
 Requires Clojure `1.10.3` or higher
 
-If using with Babashka, requires Babashka `v1.3.187` or higher
+If using with Babashka, requires Babashka `v1.12.196`(coming soon) or higher
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -815,6 +815,12 @@ First, you will need to set the general appearance of your Chrome browser's DevT
 
 
 
+> [!WARNING]
+>
+> As of November 18, 2024, The DevTools Console Customizer described below has stopped working in Chrome, most likely [due to changes made in Chrome version 130](https://github.com/paintparty/devtools-console-customizer/issues/1). Hopefully this can be fixed soon.
+
+
+
 Chrome does not offer direct options in the UI to set the exact background color or font-family of the console in dev tools. To make this simple, I created an extension called <a href="https://chromewebstore.google.com/detail/kjkmaoifmppnclfacnmbimcckfgekmod" target="_blank">DevTools Console Customizer</a>, available via <a href="https://chromewebstore.google.com/detail/kjkmaoifmppnclfacnmbimcckfgekmod" target="_blank">The Chrome Web Store</a>. The project page is <a href="https://github.com/paintparty/devtools-console-customizer" target="_blank">here</a>.
 
 After making a change with this extension, you will need to close and reopen DevTools. If you are switching from a light to dark theme or vice-versa, remember to also reset the general appearance of DevTools in **Settings** > **Preferences** > **Appearance** > **Theme**, as described above.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "ClojureScript tests for fireworks",
   "main": "index.js",
   "scripts": {
-    "test": "shadow-cljs compile test && karma start --single-run"
+    "test": "shadow-cljs compile test && karma start --single-run",
+    "node-script": "shadow-cljs compile node-script"
   },
   "keywords": [],
   "author": "",

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,8 @@
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
   :source-paths ["src"
                  ;; for local dev bling and fireworks deps
-                 ;; "../bling/src"
-                 ;; "../lasertag/src"
+                 "../bling/src"
+                 "../lasertag/src"
                  ]
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [expound "0.9.0"]

--- a/project.clj
+++ b/project.clj
@@ -5,15 +5,15 @@
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
   :source-paths ["src"
                  ;; for local dev bling and fireworks deps
-                 "../bling/src"
-                 "../lasertag/src"
+                ;;  "../bling/src"
+                 ;; "../lasertag/src"
                  ]
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [expound "0.9.0"]
                  ;; for testing
                  ;; [com.taoensso/tufte "2.6.3"]
-                 [io.github.paintparty/bling "0.2.0"]
-                 [io.github.paintparty/lasertag "0.8.3"]]
+                 [io.github.paintparty/bling "0.4.2"]
+                 [io.github.paintparty/lasertag "0.8.4"]]
   :repl-options {:init-ns fireworks.core}
   :deploy-repositories [["clojars" {:url           "https://clojars.org/repo"
                                     :sign-releases false}]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.paintparty/fireworks "0.10.4-SNAPSHOT"
+(defproject io.github.paintparty/fireworks "0.10.4"
   :description "Themeable print debugging library for Clojure, ClojureScript, and Babashka"
   :url "https://github.com/paintparty/fireworks"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -2,8 +2,7 @@
 {:source-paths ["src/" 
                 "test/"
                 ;; for local dev
-                ;; "../lasertag/src/"
-                ;; "../get-rich/src/"
+                "../lasertag/src/"
                 ]
  :dependencies [[io.github.paintparty/lasertag "0.8.3"]
                 [io.github.paintparty/bling "0.2.0"]]

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -7,7 +7,10 @@
                 ]
  :dependencies [[io.github.paintparty/lasertag "0.8.3"]
                 [io.github.paintparty/bling "0.2.0"]]
- :builds       {:test {:target    :karma
-                       :output-to "out/test.js"
-                       :ns-regexp "-test$"
-                       :autorun   true}}}
+ :builds       {:test        {:target    :karma
+                              :output-to "out/test.js"
+                              :ns-regexp "-test$"
+                              :autorun   true}
+                :node-script {:target    :node-script
+                              :main      fireworks.script-test/main
+                              :output-to "out/fireworks-in-node-demo-script.js"}}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -2,7 +2,7 @@
 {:source-paths ["src/" 
                 "test/"
                 ;; for local dev
-                "../lasertag/src/"
+                ;; "../lasertag/src/"
                 ]
  :dependencies [[io.github.paintparty/lasertag "0.8.3"]
                 [io.github.paintparty/bling "0.2.0"]]

--- a/src/fireworks/basethemes.cljc
+++ b/src/fireworks/basethemes.cljc
@@ -1,3 +1,5 @@
+;; TODO - Add :NaN, :infinity, and :-infinity
+
 ;; This is reqd by specs
 (ns fireworks.basethemes
   (:require

--- a/src/fireworks/core.cljc
+++ b/src/fireworks/core.cljc
@@ -303,9 +303,9 @@
         :file-info-str file-info*}
        form-meta
        {:formatted+ (merge {:string fmt+}
-                           #?(:cljs (when node? {:css-styles @state/styles})))
+                           #?(:cljs (when-not node? {:css-styles @state/styles})))
         :formatted  (merge {:string fmt}
-                           #?(:cljs (when node? 
+                           #?(:cljs (when-not node? 
                                       {:css-styles (subvec @state/styles 
                                                            css-count*)})))})
 

--- a/src/fireworks/profile.cljc
+++ b/src/fireworks/profile.cljc
@@ -14,16 +14,14 @@
 ;; TODO revist how your doing this, maybe there should be a :classname entry
 ;; returned from lasertag
 (def badges-by-lasertag
-  {:js/Set         "js/Set"
-   :js/Promise     "js/Promise"
-   :js/Iterator    defs/js-literal-badge
-   :js/Object      defs/js-literal-badge
-   :js/Array       defs/js-literal-badge
-   :lambda         defs/lambda-symbol
-   :transient      defs/transient-label
-   :uuid           defs/uuid-badge
-   :js/Date        defs/inst-badge
-   :java.util.Date defs/inst-badge})
+  {:js/Set      "js/Set"
+   :js/Promise  "js/Promise"
+   :js/Iterator defs/js-literal-badge
+   :js/Object   defs/js-literal-badge
+   :js/Array    defs/js-literal-badge
+   :lambda      defs/lambda-symbol
+   :transient   defs/transient-label
+   :uuid        defs/uuid-badge})
 
 
 ;; Understand and doc how this works for custom types
@@ -57,6 +55,9 @@
                  ;; Maybe this could be exposed in an option 
                  #_(or java-util-class? java-lang-class?)
                  #_classname
+
+                 (= t :inst)
+                 defs/inst-badge
 
                  (or java-util-class?
                      (and coll-type? java-lang-class?))

--- a/src/fireworks/sample.cljc
+++ b/src/fireworks/sample.cljc
@@ -1,0 +1,413 @@
+(ns fireworks.sample
+  (:require [fireworks.core :refer [? !? ?> !?>]]
+            [fireworks.themes :as themes]
+            [bling.core :refer [callout bling ?sgr]]
+            [clojure.string :as string]
+            [fireworks.pp :as pp :refer [?pp]]
+            [clojure.pprint :refer [pprint]]
+            [clojure.walk :as walk]
+            [fireworks.util :as util]
+            [lasertag.core :refer [tag-map tag]]
+            #?(:cljs [lasertag.cljs-interop])
+            #?(:cljs [cljs.js])
+            ;; [lambdaisland.ansi :as ansi]
+            )
+            
+  #?(:cljs
+     (:require-macros [fireworks.sample :refer [qc]])
+     ))
+
+;; Definitions to use in samples -----------------------------------------------
+
+(deftype MyType [a b])
+(def my-data-type (->MyType 2 3))
+(defrecord MyRecordType [a b])
+(def my-record-type (->MyRecordType "a" "b"))
+(defmulti different-behavior (fn [x] (:x-type x)))
+(defmethod different-behavior :wolf
+  [x]
+  (str (:name x) " will have a specific behavior"))
+(defn xy [x y] (+ x y))
+(defn xyv ([x y] (+ x y)) ([x y v] (+ x y v)))
+(defn xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz [x y] (+ x y))
+(def my-date (new #?(:cljs js/Date :clj java.util.Date)))
+
+;;  (def my-prom (js/Promise. (fn [x] x)))
+;;  (def prom-ref js/Promise)
+
+;; For producing example :call field in metadata of examples
+(defrecord QuotedCall [qx x])
+
+#?(:clj
+   (defmacro qc
+     "Wrap a call in a record:
+      (qc (+ 1 1))
+      =>
+      #fireworks.sample/QuotedCall{:qx '(+ 1 1) :x 2}"
+     [coll]
+     `(do (->QuotedCall (quote ~coll) ~coll))))
+
+
+
+;; Interop data ----------------------------------------------------------------
+
+#?(:cljs
+    (defn cljs-interop-classes []
+       (let [ks (keys lasertag.cljs-interop/js-built-ins-by-category)]
+         (reduce
+          (fn [acc [k v]]
+            (assoc acc
+                   (symbol k)
+                   (apply array-map
+                          (reduce (fn [acc [jsf {:keys [sym
+                                                        demo
+                                                        args
+                                                        not-a-constructor?]}]]
+                                    (conj acc
+                                          sym
+                                          (if (and (not not-a-constructor?)
+                                                   demo)
+                                            (let [res (volatile! nil)]
+                                              (cljs.js/eval-str
+                                               (cljs.js/empty-state)
+                                               demo
+                                               nil
+                                               {:eval       cljs.js/js-eval    
+                                                :source-map true
+                                                :context    :expr}
+                                               (fn [x]
+                                                 (vreset! res (:value x))))
+                                              @res)
+                                            ::no-demo
+                                            )))
+                                  []
+                                  v))))
+          {}
+          lasertag.cljs-interop/js-built-ins-by-category
+          #_(do 
+            (select-keys
+               lasertag.cljs-interop/js-built-ins-by-category
+               [
+                ;; "Fundamental"
+                ;; "objects"
+                ;; "Numbers and dates"
+                ;; "Value properties"
+                ;; "Control abstraction objects"
+                ;; "Error objects"
+                ;; "Text processing"
+                ;; "Function properties"
+                ;; "Keyed collections" 
+                "Indexed collections"
+                ;; "Structured data"
+                ;; "Internationalization"
+                ;; "Managing memory"
+                ;; "Reflection"
+                ]))))
+
+       #_(doseq [[k v] lasertag.cljs-interop/js-built-in-objects-by-object-map]
+           (? :result k)
+           (? :result v)
+           ))
+    :clj
+    ())
+
+(def interop-collection-types
+#?(:cljs ;; we get these from lasertag.cljs-interop
+   (cljs-interop-classes)
+   :clj ;; TODO - maybe move these into a new cljc lasertag.interop ns
+   (array-map 
+
+    "Java Collection Types"
+    {:java.util.ArrayList (java.util.ArrayList. (range 6))
+     :java.util.HashMap (java.util.HashMap. {"a" 1 "b" 2})
+     :java.util.HashSet (java.util.HashSet. #{"a" 1 "b" 2})
+     :java.lang.String (java.lang.String. "welcome")
+     :array (to-array '(1 2 3 4 5))}
+
+    "Java Numbers"
+    (array-map
+      :ratio               1/3
+      :byte                (byte 0)
+      :short               (short 3)
+      :double              (double 23.44)
+      :decimal             1M
+      :int                 1
+      :float               (float 1.50)
+      :char                (char 97)
+      :java.math.BigInteger (java.math.BigInteger. "171")))))
+
+
+
+;; Sample data -----------------------------------------------------------------
+
+(def everything*
+  (array-map
+
+   :primitives
+   (array-map
+    :string   "string"
+    :regex    #"myregex"
+    :uuid     (qc #uuid "4fe5d828-6444-11e8-8222-720007e40350")
+    :symbol   'mysym
+    :boolean  true
+    :keyword  :keyword
+    :nil      nil
+    :##Nan    ##NaN
+    :##Inf    ##Inf
+    :##-Inf   ##-Inf)
+
+
+   :number-types
+   (array-map
+    :int      1234
+    :float    3.33)
+
+
+   :functions    
+   (array-map
+    :lambda            #()
+    :lambda-2-args     #(+ % %2) 
+    :core-fn           juxt 
+    :date-fn   #?(:cljs
+                  js/Date
+                  :clj
+                  java.util.Date)
+    :datatype-class   MyType
+    :recordtype-class MyRecordType
+    :really-long-fn   xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz)
+
+   :collections  
+   (array-map
+    :map
+    {:a 1
+     :b 2
+     :c "three"}
+
+    :map/multi-line
+    {:abc      "bar"
+     "asdfasdfa" "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
+     [:a :b]   123444}
+
+    :array-map
+    (apply array-map
+           (mapcat (fn [x y] [x y])
+                   (range 12)
+                   ["a" "b" "c" "d" "e" "h" "i" "j" "k" "l" "m" "n"]))
+
+    :vector    
+    [1 2 3]
+
+    :vector/multi-line  
+    ["abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
+     :22222
+     3333333]
+
+    :set
+    #{1 2 3}
+
+    :list
+    '(1 2 3)
+
+    :lazy-seq
+    (range 10)
+
+    :record
+    my-record-type
+
+    ;; Leave off until you fix this
+    ;; :datatype
+    ;; my-data-type
+
+    ;; :truncation-candidate
+    ;; [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23]
+    
+    :set/single-line
+    #{1 :2 "three"}
+
+    :set/multi-line
+    #{"abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
+      :22222
+      3333333})
+
+   :interop-collection-types
+   interop-collection-types
+
+   :map-keys   
+   (array-map
+    +                              "core function"
+    "really-long-string-abcdefghi" "really-long-string-abcdefghi"
+    [1 2]                          "vector"
+    #{1 2 3}                       "set"
+    'symbol                        "symbol"
+    (with-meta 'mysym
+      {:a "foo"
+       :b [1 2 [1 2 3 4]]})        "symbol with meta"
+    #"^hi$"                        "regex"
+    #"really-long-regex-abcdefghi" "long regex"
+    1                              "number" 
+    nil                            "nil" 
+    ;; MyType               MyType
+    ;; my-data-type         my-data-type
+    ;; MyRecordType         MyRecordType
+    ;; :really-long         xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz
+    )
+
+
+   :abstractions
+   (array-map
+    :atom             (qc (atom 1))
+    :date             my-date
+    :volatile!        (volatile! 1) :transient-vector (transient [1 2 3 4])
+    :transient-set    (transient #{:a 1})
+    :transient-map    (transient {1 2 3 4})
+    )
+
+
+   :with-meta
+   (array-map
+    :nested-meta/sym (with-meta (symbol (str "foo"))
+                          (with-meta {:l1-k1 (with-meta 'a
+                                               {:l2-k1 'a
+                                                :l2-k2 'b})
+                                      :l1-k2 'b}
+                            {:l1-coll "key"}))
+    :meta/sym  (with-meta (symbol (str "foo"))
+                    (apply array-map
+                           (mapcat (fn [x y] [x y])
+                                   (range 3)
+                                   (repeat :foo))))
+    :meta/vector  ^{:foo :bar} [:foo :bar :baz]
+    :meta/vector* ^{:foo :bar} [(with-meta (symbol (str "foo"))
+                                  {:bar :baz})
+                                (with-meta (symbol (str "bar")) 
+                                  {:bar :baz})
+                                (with-meta (symbol (str "baz"))
+                                  {:bar :baz})]
+    :meta/map     ^{:foo :bar} {:one :two}
+    :meta/map*    ^{:foo :bar} {(with-meta (symbol (str "foo"))
+                                  {:bar :baz})
+                                (with-meta (symbol (str "bar"))
+                                  {:bar :baz})
+
+                                (with-meta (symbol (str "bang"))
+                                  {:bar :baz})
+                                (with-meta (symbol (str "bop"))
+                                  {:bar :baz})})))
+
+
+;; Macros and functions to produce samples -------------------------------------
+
+(defn tt*
+  [x
+   {:keys [show-extras?
+           show-extras-as-meta?
+           extras-keys]}]
+  (let [[x call] (if (instance? QuotedCall x)
+                   [(:x x) (:qx x)]
+                   [x nil])
+        extras   (when show-extras?
+                   (merge (tag-map x)
+                          (when call {:call call})))
+        extras   (or (some->> extras-keys
+                              seq
+                              (select-keys extras))
+                     extras)
+        x        (if (and show-extras? show-extras-as-meta?)
+                   (if (util/carries-meta? x)
+                     x
+                     (-> x str symbol))
+                   x)]
+    (cond (and show-extras?
+               show-extras-as-meta?)
+          (with-meta x extras)
+
+          show-extras?
+          [x extras]
+
+          :else
+          x)))
+
+
+(defn everything-with-extras
+  [coll
+   {:keys [show-extras?
+           extras-keys]
+    :as   opts}]
+  (let [coll (for [x coll] (tt* x opts))]
+    (if show-extras?
+      (apply array-map
+             (reduce (fn [acc [k v]] (conj acc k v))
+                     []
+                     coll))
+      (into [] coll))))
+
+
+(defn show-everything 
+  [cats
+   {:keys [as-vec? conj-to-vec-ks]
+    :as   opts}]
+  (let [opts (when as-vec? opts)
+        coll (everything-with-extras
+              (apply concat
+                     (for [k cats]
+                       (if as-vec?
+                         (-> everything* k vals)
+                         (-> everything* k))))
+              opts)]
+    (if as-vec?
+      (if (seq conj-to-vec-ks)
+        (apply conj
+               coll
+               (for [k conj-to-vec-ks]
+                 (-> everything* k)))
+        (do coll))
+      (apply array-map
+             (reduce (fn [acc [k v]]
+                       (conj acc
+                             k
+                             (if (instance? QuotedCall v)
+                               (:x v)
+                               v)))
+                     [] 
+                     coll)))))
+
+(def array-map-of-everything-cljc
+  (show-everything [:primitives
+                    :number-types
+                    :functions
+                    :collections
+                    :abstractions
+                    :with-meta] 
+                   {:as-vec?              false
+                    :conj-to-vec-ks       [:map-keys]
+                    :show-extras?         false
+                    :show-extras-as-meta? false
+                    :extras-keys          [:tag :call]}))
+
+(def vec-of-everything-cljc
+  (show-everything [
+                    ;; :primitives
+                    ;; :number-types
+                    ;; :functions
+                    ;; :collections
+                    :abstractions
+                    ;; :with-meta
+                    ]
+                   {:as-vec?              true
+                    ;; :conj-to-vec-ks       [:map-keys]
+                    :show-extras?         false
+                    :extras-keys          [:tag :call]}))
+
+(def vec-of-everything-cljc-with-extras
+  (show-everything [
+                    :primitives
+                    :number-types
+                    :functions
+                    :collections
+                    :abstractions
+                    :with-meta
+                    ] 
+                   {:as-vec?              true
+                    :show-extras?         true
+                    :extras-keys          [:tag :call]}))
+

--- a/src/fireworks/serialize.cljc
+++ b/src/fireworks/serialize.cljc
@@ -699,7 +699,7 @@
 
 (defn- gap-spaces
   [{:keys [s k formatting-meta? theme-token-map]}]
-  #?(:cljs s
+  #?(:cljs s ;; TODO - do we need to handle node here?
      :clj  (if formatting-meta?
              (do (when (state/debug-tagging?)
                    (println (str "\ntagging "

--- a/src/fireworks/state.cljc
+++ b/src/fireworks/state.cljc
@@ -17,8 +17,8 @@
             [fireworks.themes :as themes]
             [fireworks.util :as util]))
 
-;; debugging
 #?(:cljs
+   ;; In cljs, detect if env is node/deno vs browser
    (defonce node?
      (boolean 
       (some->> 
@@ -49,9 +49,7 @@
                       (exists? (.-version js/Deno))
                       (exists? (some-> js/Deno .-version .-deno)))
              :deno))
-       (contains? #{:deno :node}))))
-   :clj
-   ())
+       (contains? #{:deno :node})))))
 
 
 ;; Internal state atoms for development debugging ------------------------

--- a/src/fireworks/state.cljc
+++ b/src/fireworks/state.cljc
@@ -22,34 +22,33 @@
    (defonce node?
      (boolean 
       (some->> 
-       (?pp
-        (or (when (and (exists? js/window)
-                       (exists? js/window.document))
-              :browser)
+       (or (when (and (exists? js/window)
+                      (exists? js/window.document))
+             :browser)
 
-            (when (and (exists? js/process)
-                       (not (nil? (some-> js/process .-versions)))
-                       (not (nil? (some-> js/process .-versions .-node))))
-              :node)
+           (when (and (exists? js/process)
+                      (not (nil? (some-> js/process .-versions)))
+                      (not (nil? (some-> js/process .-versions .-node))))
+             :node)
 
-            (when (and (identical? "object" (js/goog.typeOf js/self))
-                       (.-constructor js/self)
-                       (= (some-> js/self .-constructor .-name)
-                          "DedicatedWorkerGlobalScope"))
-              :web-worker)
+           (when (and (identical? "object" (js/goog.typeOf js/self))
+                      (.-constructor js/self)
+                      (= (some-> js/self .-constructor .-name)
+                         "DedicatedWorkerGlobalScope"))
+             :web-worker)
 
-            (when (or (exists? js/window)
-                      (and (exists? js/navigator)
-                           (when-let [nav (.-userAgent js/navigator)]
-                             (and (identical? "object" (js/goog.typeOf nav))
-                                  (or (.includes nav "Node.js")
-                                      (.includes nav "jsdom"))))))
-              :js-dom)
+           (when (or (exists? js/window)
+                     (and (exists? js/navigator)
+                          (when-let [nav (.-userAgent js/navigator)]
+                            (and (identical? "object" (js/goog.typeOf nav))
+                                 (or (.includes nav "Node.js")
+                                     (.includes nav "jsdom"))))))
+             :js-dom)
 
-            (when (and (exists? js/Deno)
-                       (exists? (.-version js/Deno))
-                       (exists? (some-> js/Deno .-version .-deno)))
-              :deno)))
+           (when (and (exists? js/Deno)
+                      (exists? (.-version js/Deno))
+                      (exists? (some-> js/Deno .-version .-deno)))
+             :deno))
        (contains? #{:deno :node}))))
    :clj
    ())

--- a/src/fireworks/tag.cljc
+++ b/src/fireworks/tag.cljc
@@ -22,15 +22,11 @@
          m (or (f t) (f :foreground))
          m (if custom-badge-style
              (let [m (state/sanitize-style-map custom-badge-style)
-                   m (state/with-line-height m)]
-               #?(:cljs
-                  (if node?
-                    (let [m (state/map-vals state/hexa-or-sgr m)]
-                      (state/m->sgr m))
-                    (string/join (map state/kv->css2 m)) )
-                  :clj
-                  (let [m (state/map-vals state/hexa-or-sgr m)]
-                    (state/m->sgr m))))
+                   m (state/with-line-height m)
+                   f #(let [m (state/map-vals state/hexa-or-sgr m)]
+                        (state/m->sgr m))]
+               #?(:cljs (if node? (f) (string/join (map state/kv->css2 m)))
+                  :clj (f)))
              m)]
      (str m bgc))))
 
@@ -64,12 +60,14 @@
                   "%c"))
         :clj s))))
 
+(def sgr-opening-str "\033[0m")
+
 (defn tag-reset!
   ([]
    (tag-reset! :foreground))
   ([theme-token]
    #?(:cljs (if node?
-              "\033[0m"
+              sgr-opening-str
               (let [theme-token (or theme-token :foreground)]
                 (when (state/debug-tagging?)
                   (println "tag/tag-reset!  with  " theme-token))
@@ -77,7 +75,7 @@
                        conj
                        (-> @state/merged-theme theme-token))
                 "%c"))
-      :clj "\033[0m")))
+      :clj sgr-opening-str)))
 
 (defn tag-entity! 
   ([x t]

--- a/src/fireworks/themes.cljc
+++ b/src/fireworks/themes.cljc
@@ -72,20 +72,18 @@
                                    :font-style :italic}
                       :metadata   {:color            "#be55bb"
                                    :text-shadow      "0 0 2px #ffffff"
-                                   :background-color "#fae8fd"}
+                                   :background-color "#fcf0ff"}
                       :metadata2  {:color            "#9f60be"
                                    :text-shadow      "0 0 2px #ffffff"
-                                   :background-color "#e9e5ff"}
-                      :label      {:color            "#398962"
-                                   :background-color "#eefbee"
-                                   :text-shadow      "0 0 2px #ffffff"
+                                   :background-color "#ebedff"}
+                      :label      {:color            "#c76823"
+                                   :background-color "#fff9f5"
                                    :font-style       :italic}
-                      :eval-label {:color            "#4d6dba"
+                      :eval-label {:color            "#3764cd"
                                    :background-color "#edf2fc"
-                                   :text-shadow      "0 0 2px #ffffff"
                                    :font-style       :italic}}
             :syntax  {:js-object-key {:color "#888888"}}
-            :printer {:file-info     {:color                "#4d6dba"
+            :printer {:file-info     {:color                "#3764cd"
                                       :font-style           :italic
                                       :padding-inline-start :0ch}
                       :eval-form     :eval-label

--- a/src/fireworks/truncate.cljc
+++ b/src/fireworks/truncate.cljc
@@ -1,6 +1,7 @@
 (ns ^:dev/always fireworks.truncate
   (:require #?(:cljs [fireworks.macros :refer-macros [keyed]])
             #?(:clj [fireworks.macros :refer [keyed]])
+            [fireworks.pp :refer [?pp]]
             [clojure.string :as string]
             [fireworks.ellipsize :as ellipsize]
             [fireworks.order :refer [seq->sorted-map]]
@@ -197,11 +198,13 @@
         val-is-volatile? (volatile? x) 
         x                (if (or val-is-atom? val-is-volatile?) @x x)
         kv?              (boolean (when-not map-entry-in-non-map? (map-entry? x)))
-        tag-map          (when-not kv? (util/tag-map* x) )
+        tag-map          (when-not kv? (util/tag-map* x))
         x                (reify-if-transient x tag-map)
         too-deep?        (> depth (:print-level @state/config))
+
         sev?             (boolean (when-not kv?
                                     (not (:coll-type? tag-map))))]
+
     (merge m* ;; m* added for :key? and :map-value? entries
            (keyed [val-is-atom?
                    val-is-volatile?
@@ -223,6 +226,7 @@
   [{:keys [coll-type? kv? depth carries-meta?]
     :as m}
    x]
+  ;; (println "\n\nx in truncated-x*" x)
   (let [x (cond
             kv?        
             (let [[k v] x]

--- a/test/fireworks/core_test.cljc
+++ b/test/fireworks/core_test.cljc
@@ -1,13 +1,15 @@
 (ns fireworks.core-test
-  (:require [clojure.string :as string]
-            [fireworks.core :refer [? !? ?> !?>]]
-            [fireworks.config]
-            [fireworks.pp :as pp :refer [?pp]]
-            [fireworks.smoke-test :as smoke-test]
-            [fireworks.demo]
-            [fireworks.themes :as themes]
-            #?(:cljs [cljs.test :refer [deftest is]])
-            #?(:clj [clojure.test :refer :all])))
+  (:require 
+   [clojure.string :as string]
+   [fireworks.core :refer [? !? ?> !?>]]
+   [fireworks.config]
+   [fireworks.pp :as pp :refer [?pp !?pp]]
+   [fireworks.smoke-test :as smoke-test]
+   [fireworks.demo]
+   [fireworks.themes :as themes] 
+   [fireworks.sample :as sample] 
+   #?(:cljs [cljs.test :refer [deftest is]])
+   #?(:clj [clojure.test :refer :all])))
 
 ;; These tests will break if your local ~/.fireworks/config.edn is different from fireworks.smoke-test/example-config.
 ;; Change it to that temporarily if you want to run these tests locally. This will be fixed in the near future.
@@ -19,18 +21,19 @@
 #?(:cljs
    (deftest p-data-basic 
      (is (=
-          (let [ret (? :data {:theme theme} "foo")] #_(pp/pprint "p-data basic") #_(pp/pprint ret) ret)
+          (let [ret (? :data {:theme theme} "foo")] (!?pp 'p-data-basic ret))
           {:quoted-form   "foo",
-           :formatted     {:string     "%c\"foo\"%c"
-                           :css-styles ["color:#448C27;line-height:1.45;" "color:#585858;line-height:1.45;"]},
+           :formatted     {:string     "%c\"foo\"%c",
+                           :css-styles ["color:#448C27;line-height:1.45;"
+                                        "color:#585858;line-height:1.45;"]},
            :file          "fireworks/core_test.cljc",
            :end-column    51,
            :ns-str        "fireworks.core-test",
-           :file-info-str "fireworks.core-test:22:21",
+           :file-info-str "fireworks.core-test:24:21",
            :column        21,
-           :line          22,
-           :end-line      22,
-           :formatted+    {:string     "%cfoo%c  %cfireworks.core-test:22:21%c%c \n%c%c\"foo\"%c",
+           :line          24,
+           :end-line      24,
+           :formatted+    {:string     "%cfoo%c  %cfireworks.core-test:24:21%c%c \n%c%c\"foo\"%c",
                            :css-styles ["color:#4d6dba;background-color:#edf2fc;text-shadow:0 0 2px #ffffff;font-style:italic;line-height:1.45;"
                                         "color:#585858;line-height:1.45;"
                                         "color:#4d6dba;font-style:italic;padding-inline-start:0ch;line-height:1.45;"
@@ -42,21 +45,22 @@
 #?(:cljs
    (deftest p-data-with-label
      (is (= 
-          (let [ret (? :data "my-label" "foo")] #_(pp/pprint "p-data-with-label") #_(pp/pprint ret) ret)
+          (let [ret (? :data "my-label" "foo")] (!?pp 'p-data-with-label ret))
           {:quoted-form   "foo",
-           :formatted     {:string     "%c\"foo\"%c"
-                           :css-styles ["color:#448C27;line-height:1.45;" "color:#585858;line-height:1.45;"]},
+           :formatted     {:string     "%c\"foo\"%c",
+                           :css-styles ["color:#448C27;line-height:1.45;"
+                                        "color:#585858;line-height:1.45;"]},
            :file          "fireworks/core_test.cljc",
            :end-column    47,
            :ns-str        "fireworks.core-test",
-           :file-info-str "fireworks.core-test:45:21",
+           :file-info-str "fireworks.core-test:48:21",
            :column        21,
-           :line          45,
-           :end-line      45,
-           :formatted+    {:string     "%cmy-label%c  %cfireworks.core-test:45:21%c%c \n%c%c\"foo\"%c",
-                           :css-styles ["color:#4d6dba;background-color:#edf2fc;text-shadow:0 0 2px #ffffff;font-style:italic;line-height:1.45;"
+           :line          48,
+           :end-line      48,
+           :formatted+    {:string     "%cmy-label%c  %cfireworks.core-test:48:21%c%c \n%c%c\"foo\"%c",
+                           :css-styles ["color:#3764cd;background-color:#edf2fc;font-style:italic;line-height:1.45;"
                                         "color:#585858;line-height:1.45;"
-                                        "color:#4d6dba;font-style:italic;padding-inline-start:0ch;line-height:1.45;"
+                                        "color:#3764cd;font-style:italic;padding-inline-start:0ch;line-height:1.45;"
                                         "color:#585858;line-height:1.45;"
                                         "color:;margin-block-end:0.5em;line-height:1.45;"
                                         "color:#585858;line-height:1.45;"
@@ -65,203 +69,11 @@
 
 
 #?(:cljs
-   (do (deftest p-data-with-label-from-opts
-         (is (= 
-              (let [ret (? :data {:label                 "my-label-from-opts"
-                                  :theme                 theme
-                                  :non-coll-length-limit (-> fireworks.config/options
-                                                             :non-coll-length-limit
-                                                             :default)}
-                           "foo")]
-                ;; (pp/pprint 'p-data-with-label-from-opts)
-                ;; (pp/pprint ret)
-                ret)
-              {:quoted-form   "foo",
-               :formatted     {:string     "%c\"foo\"%c",
-                               :css-styles ["color:#448C27;line-height:1.45;"
-                                            "color:#585858;line-height:1.45;"]},
-               :file          "fireworks/core_test.cljc",
-               :end-column    34,
-               :ns-str        "fireworks.core-test",
-               :file-info-str "fireworks.core-test:70:25",
-               :column        25,
-               :line          70,
-               :end-line      75,
-               :formatted+    {:string     "%cmy-label-from-opts%c  %cfireworks.core-test:70:25%c%c \n%c%c\"foo\"%c",
-                               :css-styles ["color:#4d6dba;background-color:#edf2fc;text-shadow:0 0 2px #ffffff;font-style:italic;line-height:1.45;"
-                                            "color:#585858;line-height:1.45;"
-                                            "color:#4d6dba;font-style:italic;padding-inline-start:0ch;line-height:1.45;"
-                                            "color:#585858;line-height:1.45;"
-                                            "color:;margin-block-end:0.5em;line-height:1.45;"
-                                            "color:#585858;line-height:1.45;"
-                                            "color:#448C27;line-height:1.45;"
-                                            "color:#585858;line-height:1.45;"]}})))
+   nil
 
-       
-       
-       (deftest p-data-with-coll-limit
-         (is (= 
-              (let [ret              (? :data {:label                      "my-label"
-                                               :enable-terminal-truecolor? true
-                                               :enable-terminal-italics?   true
-                                               :coll-limit                 5
-                                               :theme                      theme}
-                                        [1 2 3 4 5 6 7 8])
-                    formatted-string (-> ret :formatted :string)]
-                ;; (pp/pprint formatted-string)
-                formatted-string)
-              "%c[%c%c1%c %c2%c %c3%c %c4%c %c5%c%c ...+3%c%c]%c")))
-
-       (deftest p-data-with-non-coll-level-1-depth-length-limit
-         (is (= 
-              (let [ret              (? :data {:label                         "my-label"
-                                               :enable-terminal-truecolor?    true
-                                               :enable-terminal-italics?      true
-                                               :bracket-contrast              "high"
-                                               :theme                         theme
-                                               :non-coll-depth-1-length-limit 60}
-                                        ["asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas"])
-                    formatted-string (-> ret :formatted :string)]
-                ;; (pp/pprint formatted-string)
-                formatted-string)
-              "%c[%c%c\"asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44\"%c...%c%c%c]%c")))
-
-       (deftest p-data-with-non-coll-length-limit
-         (is (= 
-              (let [ret              (? :data {:label                        "my-label"
-                                               :enable-terminal-truecolor?   true
-                                               :enable-terminal-italics?     true
-                                               :bracket-contrast             "high"
-                                               :theme                        theme
-                                               :non-coll-result-length-limit 42}
-                                        "asdfffaaaaasdfasdfasdfasdfasdfasdfasdfaaaafasdfasdfff44asdffffffas")
-                    formatted-string (-> ret :formatted :string)]
-                ;; (pp/pprint 'p-data-with-non-coll-length-limit)
-                ;; (pp/pprint formatted-string)
-                formatted-string)
-              "%c\"asdfffaaaaasdfasdfasdfasdfasdfasdfasd\"...%c")))
-
-       (deftest p-data-rainbow-brackets
-         (is (= 
-              (let [ret              (? :data {:label                      "my-label"
-                                               :enable-terminal-truecolor? true
-                                               :enable-terminal-italics?   true
-                                               :bracket-contrast           "high"
-                                               :theme                      theme}
-                                        [[[[[]]]]])
-                    formatted-string (-> ret :formatted :string)]
-                ;; (pp/pprint formatted-string)
-                formatted-string)
-              "%c[%c%c[%c%c[%c%c[%c%c[%c%c]%c%c]%c%c]%c%c]%c%c]%c")))
-       
-       (deftest p-data-record-sample-in-atom
-         (is (= 
-              (let [ret              (? :data {:label                      "my-label"
-                                               :enable-terminal-truecolor? true
-                                               :enable-terminal-italics?   true
-                                               :bracket-contrast           "high"
-                                               :theme                      theme}
-                                        (atom smoke-test/record-sample))
-                    formatted-string (-> ret :formatted :string)]
-                ;; (pp/pprint 'p-data-record-sample-in-atom)
-                ;; (pp/pprint formatted-string)
-                formatted-string)
-              "%cAtom<%c%cFoos%c\n%c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c")))
-       
-
-       ;; Leave this out until you support native logging
-       (deftest p-data-js-array
-         (is (= 
-              (let [ret              (? :data {:label                      "my-label"
-                                               :enable-terminal-truecolor? true
-                                               :enable-terminal-italics?   true
-                                               :bracket-contrast           "high"
-                                               :theme                      theme}
-                                        #js [1 2 3])
-                    formatted-string (-> ret :formatted :string)]
-                ;; (pp/pprint 'p-data-js-array)
-                ;; (pp/pprint formatted-string)
-                formatted-string)
-              nil)))
-
-       (deftest p-data-js-object
-         (is (= 
-              (let [ret              (? :data {:label                      "my-label"
-                                               :enable-terminal-truecolor? true
-                                               :enable-terminal-italics?   true
-                                               :bracket-contrast           "high"
-                                               :theme                      theme}
-                                        #js {:a 1 :b 2})
-                    formatted-string (-> ret :formatted :string)]
-                ;; (pp/pprint 'p-data-js-object)
-                ;; (pp/pprint formatted-string)
-                formatted-string)
-              nil)))
-       
-       (deftest p-data-record-sample-in-volatile
-         (is (= 
-              (let [ret              (? :data {:label                      "my-label"
-                                               :enable-terminal-truecolor? true
-                                               :enable-terminal-italics?   true
-                                               :bracket-contrast           "high"
-                                               :theme                      theme}
-                                        (volatile! smoke-test/record-sample))
-                    formatted-string (-> ret :formatted :string)]
-                ;; (pp/pprint 'p-data-record-sample-in-volatile)
-                ;; (pp/pprint formatted-string)
-                formatted-string)
-              "%cVolatile<%c%cFoos%c\n%c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c")))
-
-       
-
-       ;; Leave this out until you figure out what is going on with transients in node-based testing
-       #_(deftest transient-vector
-           (is (= 
-                (let [ret              (let [x   (transient [1 2 3 4 5 6 7 8 9 0])
-                                             ret (? :data {:coll-limit                 7
-                                                           :label                      "my-label"
-                                                           :enable-terminal-truecolor? true
-                                                           :enable-terminal-italics?   true
-                                                           :bracket-contrast           "high"
-                                                           :theme                      theme}
-                                                    x)]
-                                         (conj! x 5)
-                                         ret)
-
-                      _                (do (println "FUUUU")
-                                           (pp/pprint ret))
-                      formatted-string (-> ret :formatted :string)]
-                  (pp/pprint ret)
-                  (pp/pprint 'transient-vector)
-                  (pp/pprint formatted-string)
-                  formatted-string)
-                "%cVolatile<%c%cFoos%c\n%c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c")))
-
-
-       ;; Leave this out until you support custom printers 
-       #_(deftest p-data-custom-printers
-           (is (= 
-                (let [ret              (p-data {:custom-printers {:vector {:pred        (fn [x] (= x [1 2 3 4]))
-                                                                           :f           (fn [x] (into #{} x))
-                                                                           :badge-text  " Set💩 "
-                                                                           :badge-style {:color            "#000"
-                                                                                         :background-color "lime"
-                                                                                         :border-radius    "999px"
-                                                                                         :text-shadow      "none"
-                                                                                         :font-style       "normal"}}}}
-                                               [1 2 3 4])
-                      formatted-string (-> ret :formatted :string)]
-                  (pp/pprint formatted-string)
-                  formatted-string)
-                "%c Set💩 %c
-%c#{%c%c1%c %c2%c %c3%c %c4%c%c}%c")))
-       )
- 
-
-
-   :clj #_nil
+   :clj
    (do 
-     (deftest  p-data-with-label-from-opts ;; line+column dependant
+     #_(deftest  p-data-with-label-from-opts ;; line+column dependant
        (is (= 
             (let [ret              (? :data {:label                      "my-label"
                                              :enable-terminal-truecolor? true
@@ -274,7 +86,7 @@
               (string/join (escape-sgr formatted-string)))
             "〠3;38;2;77;109;186;48;2;237;242;252〠my-label〠0〠  〠3;38;2;77;109;186〠fireworks.core-test:266:36〠0〠〠〠 \n〠0〠〠38;2;68;140;39〠\"foo\"〠0〠")))
 
-     (deftest p-data-with-label-from-opts-primitive-terminal-emulator ;; line+column dependant
+     #_(deftest p-data-with-label-from-opts-primitive-terminal-emulator ;; line+column dependant
        (is (= 
             (let [ret              (? :data {:label                      "my-label"
                                              :enable-terminal-truecolor? false
@@ -365,12 +177,12 @@
                                              :enable-terminal-italics?   true
                                              :bracket-contrast           "high"
                                              :theme                      theme}
-                                      (atom smoke-test/record-sample))
-                  formatted-string (-> ret :formatted :string)]
-              ;; (pp/pprint 'p-data-record-sample-in-atom)
-              ;; (pp/pprint (escape-sgr formatted-string))
-              (string/join (escape-sgr formatted-string)))
-            "〠3;38;2;57;137;98;48;2;238;251;238〠Atom<〠0〠〠3;38;2;57;137;98;48;2;238;251;238〠Foos〠0〠\n〠38;5;241;48;2;238;251;238〠{〠0〠〠38;2;122;62;157〠:a〠0〠 〠38;2;122;62;157〠1〠0〠 〠38;2;122;62;157〠:b〠0〠 〠38;2;122;62;157〠2〠0〠〠38;5;241;48;2;238;251;238〠}〠0〠〠3;38;2;57;137;98;48;2;238;251;238〠>〠0〠")))
+                                      (atom smoke-test/my-record-type))
+                  formatted-string (-> ret :formatted :string)
+                  escaped          (string/join (escape-sgr formatted-string))]
+              #_(?pp 'p-data-record-sample-in-atom escaped)
+              escaped)
+            "〠3;38;2;57;137;98;48;2;238;251;238〠Atom<〠0〠〠3;38;2;57;137;98;48;2;238;251;238〠MyRecordType〠0〠\n〠38;5;241;48;2;238;251;238〠{〠0〠〠38;2;122;62;157〠:a〠0〠 〠38;2;68;140;39〠\"a\"〠0〠 〠38;2;122;62;157〠:b〠0〠 〠38;2;68;140;39〠\"b\"〠0〠〠38;5;241;48;2;238;251;238〠}〠0〠〠3;38;2;57;137;98;48;2;238;251;238〠>〠0〠")))
 
      (deftest p-data-record-sample
        (is (= 
@@ -379,12 +191,12 @@
                                              :enable-terminal-italics?   true
                                              :bracket-contrast           "high"
                                              :theme                      theme}
-                                      smoke-test/record-sample)
-                  formatted-string (-> ret :formatted :string)]
-              ;; (pp/pprint 'p-data-record-sample)
-              ;; (pp/pprint (escape-sgr formatted-string))
-              (string/join (escape-sgr formatted-string)))
-            (str "〠3;38;2;57;137;98;48;2;238;251;238〠" "Foos" "〠0〠" "\n" "〠38;5;241;48;2;238;251;238〠" "{" "〠0〠" "〠38;2;122;62;157〠" ":a" "〠0〠" " " "〠38;2;122;62;157〠" "1" "〠0〠" " " "〠38;2;122;62;157〠" ":b" "〠0〠" " " "〠38;2;122;62;157〠" "2" "〠0〠" "〠38;5;241;48;2;238;251;238〠" "}" "〠0〠"))))
+                                      smoke-test/my-record-type)
+                  formatted-string (-> ret :formatted :string)
+                  escaped          (string/join (escape-sgr formatted-string))]
+              #_(?pp 'p-data-record-sample escaped)
+              escaped)
+            "〠3;38;2;57;137;98;48;2;238;251;238〠MyRecordType〠0〠\n〠38;5;241;48;2;238;251;238〠{〠0〠〠38;2;122;62;157〠:a〠0〠 〠38;2;68;140;39〠\"a\"〠0〠 〠38;2;122;62;157〠:b〠0〠 〠38;2;68;140;39〠\"b\"〠0〠〠38;5;241;48;2;238;251;238〠}〠0〠")))
 
      (deftest p-data-symbol-with-meta
        (is (= 
@@ -575,16 +387,17 @@
 
 ;; Basic print-and-return tests, cljc
 (do
-  (deftest ?-par-result
-    (is (= (? :result "par?") "par?")))
-  (deftest ?-par
-    (is (= (? "par?") "par?")))
-  (deftest !?-par
-    (is (= (!? "par?") "par?")))
-  (deftest ?>-par
-    (is (= (?> "par?") "par?")))
-  (deftest !?>-par
-    (is (= (!?> "par?") "par?")))
+  ;; (deftest ?-par-result
+  ;;   (is (= (? :result "par?") "par?")))
+  ;; (deftest ?-par
+  ;;   (is (= (? "par?") "par?")))
+  ;; (deftest !?-par
+  ;;   (is (= (!? "par?") "par?")))
+  ;; (deftest ?>-par
+  ;;   (is (= (?> "par?") "par?")))
+  ;; (deftest !?>-par
+  ;;   (is (= (!?> "par?") "par?")))
+
   (deftest p-data-basic-samples
          (is (= 
               (let [ret              
@@ -611,25 +424,19 @@
                         :non-coll-mapkey-length-limit (-> fireworks.config/options
                                                           :non-coll-mapkey-length-limit
                                                           :default)}
-                       smoke-test/basic-samples-cljc)
+                       sample/array-map-of-everything-cljc)
 
                     formatted-string 
                     #?(:cljs
                        (-> ret :formatted :string)
                        :clj
                        (string/join (escape-sgr (-> ret :formatted :string))))]
-                #?(:clj (do 
-                          ;; (pp/pprint 'p-data-basic-samples)
-                          ;; (pp/pprint formatted-string)
-                          formatted-string)
-                   :cljs (do 
-                          ;;  (pp/pprint 'p-data-basic-samples)
-                          ;;  (pp/pprint formatted-string)
-                           formatted-string)))
+                #?(:clj (do (!?pp 'p-data-basic-samples formatted-string))
+                   :cljs (do (!?pp 'p-data-basic-samples formatted-string))))
               #?(:clj
-                 "〠38;5;241〠{〠0〠〠38;2;122;62;157〠:abcdefg〠0〠 〠38;5;32〠{〠0〠〠38;2;122;62;157〠:boolean〠0〠            〠38;2;122;62;157〠true〠0〠\n           〠38;2;122;62;157〠:brackets〠0〠           〠38;5;208〠[〠0〠〠38;5;28〠[〠0〠〠38;5;128〠[〠0〠〠38;5;241〠[〠0〠〠38;5;32〠[〠0〠〠38;5;208〠[〠0〠〠38;5;208〠]〠0〠〠38;5;32〠]〠0〠〠38;5;241〠]〠0〠〠38;5;128〠]〠0〠〠38;5;28〠]〠0〠〠38;5;208〠]〠0〠\n           〠38;2;122;62;157〠:fn〠0〠                 〠38;2;77;109;186〠clojure.core/juxt〠0〠〠38;2;153;153;153〠[]〠0〠\n           〠38;2;122;62;157〠:lambda〠0〠             〠3;38;2;57;137;98;48;2;238;251;238〠λ〠0〠〠38;2;77;109;186〠〠0〠〠38;2;153;153;153〠[]〠0〠\n           〠38;2;122;62;157〠:number〠0〠             〠38;2;122;62;157〠1234〠0〠\n           〠38;2;122;62;157〠:record〠0〠             〠3;38;2;57;137;98;48;2;238;251;238〠Foos〠0〠\n                               〠38;5;208;48;2;238;251;238〠{〠0〠〠38;2;122;62;157〠:a〠0〠 〠38;2;122;62;157〠1〠0〠 〠38;2;122;62;157〠:b〠0〠 〠38;2;122;62;157〠2〠0〠〠38;5;208;48;2;238;251;238〠}〠0〠\n           〠38;2;122;62;157〠:regex〠0〠              〠38;2;68;140;39〠#\"^hi$\"〠0〠\n           〠38;2;122;62;157〠:string〠0〠             〠38;2;68;140;39〠\"string\"〠0〠\n           〠38;2;122;62;157〠:symbol〠0〠             〠38;2;77;109;186〠mysym〠0〠 〠38;2;190;85;187;48;2;250;232;253〠    〠0〠〠38;2;190;85;187;48;2;250;232;253〠^{〠0〠〠38;2;190;85;187;48;2;250;232;253〠:foo〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠:bar〠0〠〠38;2;190;85;187;48;2;250;232;253〠}〠0〠\n           〠38;2;122;62;157〠:symbol2〠0〠            〠38;2;77;109;186〠mysym〠0〠 〠38;2;190;85;187;48;2;250;232;253〠    〠0〠〠38;2;190;85;187;48;2;250;232;253〠^{〠0〠〠38;2;190;85;187;48;2;250;232;253〠:foo〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠[〠0〠〠38;2;190;85;187;48;2;250;232;253〠\"afasdfasf\"〠0〠〠38;2;88;88;88〠\n                                                 〠0〠〠38;2;190;85;187;48;2;250;232;253〠\"afasdfasf\"〠0〠〠38;2;88;88;88〠\n                                                 〠0〠〠38;2;190;85;187;48;2;250;232;253〠{〠0〠〠38;2;190;85;187;48;2;250;232;253〠:a〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠\"foo\"〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠:b〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠[〠0〠〠38;2;190;85;187;48;2;250;232;253〠1〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠2〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠[〠0〠〠38;2;190;85;187;48;2;250;232;253〠1〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠2〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠3〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠4〠0〠〠38;2;190;85;187;48;2;250;232;253〠]〠0〠〠38;2;190;85;187;48;2;250;232;253〠]〠0〠〠38;2;190;85;187;48;2;250;232;253〠}〠0〠〠38;2;88;88;88〠\n                                                 〠0〠〠38;2;190;85;187;48;2;250;232;253〠\"afasdfasf\"〠0〠〠38;2;88;88;88〠\n                                                 〠0〠〠38;2;190;85;187;48;2;250;232;253〠\"afasdfasf\"〠0〠〠38;2;190;85;187;48;2;250;232;253〠]〠0〠〠38;2;88;88;88〠\n                                           〠0〠〠38;2;190;85;187;48;2;250;232;253〠:bar〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠\"fooz\"〠0〠〠38;2;190;85;187;48;2;250;232;253〠}〠0〠\n           〠38;2;122;62;157〠:uuid〠0〠               〠3;38;2;57;137;98;48;2;238;251;238〠#uuid 〠0〠〠38;2;68;140;39〠\"4fe5d828-6444-11e8-822\"〠3;38;2;140;140;140〠...〠0〠〠0〠\n           〠38;2;122;62;157〠:atom/number〠0〠        〠3;38;2;57;137;98;48;2;238;251;238〠Atom<〠0〠〠38;2;122;62;157〠1〠0〠〠3;38;2;57;137;98;48;2;238;251;238〠>〠0〠\n           〠38;2;122;62;157〠:atom/record〠0〠        〠3;38;2;57;137;98;48;2;238;251;238〠Atom<〠0〠〠3;38;2;57;137;98;48;2;238;251;238〠Foos〠0〠\n                               〠38;5;208;48;2;238;251;238〠{〠0〠〠38;2;122;62;157〠:a〠0〠 〠38;2;122;62;157〠1〠0〠 〠38;2;122;62;157〠:b〠0〠 〠38;2;122;62;157〠2〠0〠〠38;5;208;48;2;238;251;238〠}〠0〠〠3;38;2;57;137;98;48;2;238;251;238〠>〠0〠\n           〠38;2;122;62;157〠:map/multi-line〠0〠     〠38;5;208〠{〠0〠〠38;2;122;62;157〠:abc〠0〠〠38;2;88;88;88〠\n                                〠0〠〠38;2;68;140;39〠\"bar\"〠0〠〠38;2;88;88;88〠\n                                \n                                〠0〠〠38;2;68;140;39〠\"asdfasdfa\"〠0〠〠38;2;88;88;88〠\n                                〠0〠〠38;2;68;140;39〠\"abcdefghijklmnopqrstuvwxyzzz\"〠3;38;2;140;140;140〠...〠0〠〠0〠〠38;2;88;88;88〠\n                                \n                                〠0〠〠38;5;28〠[〠0〠〠38;2;122;62;157〠:a〠0〠 〠38;2;122;62;157〠:b〠0〠〠38;5;28〠]〠0〠〠38;2;88;88;88〠\n                                〠0〠〠38;2;122;62;157〠123444〠0〠〠38;5;208〠}〠0〠\n           〠38;2;122;62;157〠:map/nested-meta〠0〠    〠38;5;208;48;2;250;232;253〠{〠0〠 〠38;2;190;85;187;48;2;250;232;253〠    〠0〠〠38;2;190;85;187;48;2;250;232;253〠^{〠0〠〠38;2;190;85;187;48;2;250;232;253〠:a〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠foo〠0〠 〠38;2;159;96;190;48;2;233;229;255〠    〠0〠〠38;2;159;96;190;48;2;233;229;255〠^{〠0〠〠38;2;159;96;190;48;2;233;229;255〠:abc〠0〠〠38;2;159;96;190;48;2;233;229;255〠 〠0〠〠38;2;159;96;190;48;2;233;229;255〠bar〠0〠〠38;2;88;88;88〠\n                                                    〠0〠〠38;2;159;96;190;48;2;233;229;255〠:xyz〠0〠〠38;2;159;96;190;48;2;233;229;255〠 〠0〠〠38;2;159;96;190;48;2;233;229;255〠\"abcdefghijklmnopqrstuvwxyzzzz\"〠38;2;159;96;190;48;2;233;229;255〠...〠0〠〠0〠〠38;2;159;96;190;48;2;233;229;255〠}〠0〠〠38;2;190;85;187;48;2;250;232;253〠}〠0〠〠38;2;88;88;88〠\n                                〠0〠〠38;2;77;109;186〠a〠0〠 〠38;2;190;85;187;48;2;250;232;253〠    〠0〠〠38;2;190;85;187;48;2;250;232;253〠^{〠0〠〠38;2;190;85;187;48;2;250;232;253〠:abc〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠\"bar\"〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠:xyz〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠\"abc\"〠0〠〠38;2;190;85;187;48;2;250;232;253〠}〠0〠〠38;2;88;88;88〠\n                                〠0〠〠38;2;77;109;186〠foo〠0〠 〠38;2;190;85;187;48;2;250;232;253〠    〠0〠〠38;2;190;85;187;48;2;250;232;253〠^{〠0〠〠38;2;190;85;187;48;2;250;232;253〠:abc〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠\"bar\"〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠:xyz〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠\"abc\"〠0〠〠38;2;190;85;187;48;2;250;232;253〠}〠0〠〠38;2;88;88;88〠\n                                \n                                〠0〠〠38;2;122;62;157〠:b〠0〠〠38;2;88;88;88〠\n                                〠0〠〠38;2;122;62;157〠2〠0〠〠38;5;208;48;2;250;232;253〠}〠0〠\n           〠38;2;122;62;157〠:map/single-line〠0〠    〠38;5;208〠{〠0〠〠38;2;122;62;157〠:a〠0〠 〠38;2;122;62;157〠1〠0〠 〠38;2;122;62;157〠:b〠0〠 〠38;2;122;62;157〠2〠0〠 〠38;2;122;62;157〠:c〠0〠 〠38;2;68;140;39〠\"three\"〠0〠〠38;5;208〠}〠0〠\n           〠38;2;122;62;157〠:set/multi-line〠0〠     〠38;5;208〠#{〠0〠〠38;2;68;140;39〠\"abcdefghijklmnopqrstuvwxyzzz\"〠3;38;2;140;140;140〠...〠0〠〠0〠〠38;2;88;88;88〠\n                                 〠0〠〠38;2;122;62;157〠3333333〠0〠〠38;2;88;88;88〠\n                                 〠0〠〠38;2;122;62;157〠:22222〠0〠〠38;5;208〠}〠0〠\n           〠38;2;122;62;157〠:set/single-line〠0〠    〠38;5;208〠#{〠0〠〠38;2;122;62;157〠1〠0〠 〠38;2;68;140;39〠\"three\"〠0〠 〠38;2;122;62;157〠:2〠0〠〠38;5;208〠}〠0〠\n           〠38;2;122;62;157〠:vector/multi-line〠0〠  〠38;5;208〠[〠0〠〠38;2;68;140;39〠\"abcdefghijklmnopqrstuvwxyzzz\"〠3;38;2;140;140;140〠...〠0〠〠0〠〠38;2;88;88;88〠\n                                〠0〠〠38;2;122;62;157〠:22222〠0〠〠38;2;88;88;88〠\n                                〠0〠〠38;2;122;62;157〠3333333〠0〠〠38;5;208〠]〠0〠\n           〠38;2;122;62;157〠:vector/single-line〠0〠 〠38;5;208〠[〠0〠〠38;2;122;62;157〠1〠0〠 〠38;2;122;62;157〠:2〠0〠 〠38;2;68;140;39〠\"three\"〠0〠〠38;5;208〠]〠0〠〠38;5;32〠}〠0〠〠38;5;241〠}〠0〠"
+                 "〠38;5;241〠{〠0〠〠38;2;122;62;157〠:string〠0〠           〠38;2;68;140;39〠\"string\"〠0〠\n 〠38;2;122;62;157〠:regex〠0〠            〠38;2;68;140;39〠#\"myregex\"〠0〠\n 〠38;2;122;62;157〠:uuid〠0〠             〠3;38;2;57;137;98;48;2;238;251;238〠#uuid 〠0〠〠38;2;68;140;39〠\"4fe5d828-6444-11e8-8222\"〠3;38;2;140;140;140〠...〠0〠〠0〠\n 〠38;2;122;62;157〠:symbol〠0〠           〠38;2;77;109;186〠mysym〠0〠\n 〠38;2;122;62;157〠:boolean〠0〠          〠38;2;122;62;157〠true〠0〠\n 〠38;2;122;62;157〠:keyword〠0〠          〠38;2;122;62;157〠:keyword〠0〠\n 〠38;2;122;62;157〠:nil〠0〠              〠38;2;122;62;157〠nil〠0〠\n 〠38;2;122;62;157〠:##Nan〠0〠            〠38;2;122;62;157〠NaN〠0〠\n 〠38;2;122;62;157〠:##Inf〠0〠            〠38;2;122;62;157〠Infinity〠0〠\n 〠38;2;122;62;157〠:##-Inf〠0〠           〠38;2;122;62;157〠-Infinity〠0〠\n 〠38;2;122;62;157〠:int〠0〠              〠38;2;122;62;157〠1234〠0〠\n 〠38;2;122;62;157〠:float〠0〠            〠38;2;122;62;157〠3.33〠0〠\n 〠38;2;122;62;157〠:lambda〠0〠           〠3;38;2;57;137;98;48;2;238;251;238〠λ〠0〠〠38;2;77;109;186〠〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:lambda-2-args〠0〠    〠3;38;2;57;137;98;48;2;238;251;238〠λ〠0〠〠38;2;77;109;186〠〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:core-fn〠0〠          〠38;2;77;109;186〠clojure.core/juxt〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:date-fn〠0〠          〠38;2;77;109;186〠java.util/Date〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:datatype-class〠0〠   〠38;2;77;109;186〠fireworks.sample/MyType〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:recordtype-class〠0〠 〠38;2;77;109;186〠fireworks.sample/MyRecordType〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:really-long-fn〠0〠   〠38;2;77;109;186〠xyasldfasldkfaslkjfzzzzzzzzzz〠3;38;2;140;140;140〠...〠0〠〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:map〠0〠              〠38;5;32〠{〠0〠〠38;2;122;62;157〠:a〠0〠 〠38;2;122;62;157〠1〠0〠 〠38;2;122;62;157〠:b〠0〠 〠38;2;122;62;157〠2〠0〠 〠38;2;122;62;157〠:c〠0〠 〠38;2;68;140;39〠\"three\"〠0〠〠38;5;32〠}〠0〠〠3;38;2;140;140;140〠\n ...               ...+22〠0〠〠38;5;241〠}〠0〠"
                  :cljs
-                 "%c{%c%c:abcdefg%c %c{%c%c:boolean%c            %ctrue%c\n           %c:brackets%c           %c[%c%c[%c%c[%c%c[%c%c[%c%c[%c%c]%c%c]%c%c]%c%c]%c%c]%c%c]%c\n           %c:fn%c                 %ccljs.core/juxt%c%c[var_args]%c\n           %c:lambda%c             %cλ%c%c%c%c[%1]%c\n           %c:number%c             %c1234%c\n           %c:record%c             %cFoos%c\n                               %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c\n           %c:regex%c              %c#\"^hi$\"%c\n           %c:string%c             %c\"string\"%c\n           %c:symbol%c             %cmysym%c %c    %c%c^{%c%c:foo%c %c:bar%c%c}%c\n           %c:symbol2%c            %cmysym%c %c    %c%c^{%c%c:foo%c %c[%c%c\"afasdfasf\"%c%c\n                                                 %c%c\"afasdfasf\"%c%c\n                                                 %c%c{%c%c:a%c %c\"foo\"%c%c %c%c:b%c %c[%c%c1%c%c %c%c2%c%c %c%c[%c%c1%c%c %c%c2%c%c %c%c3%c%c %c%c4%c%c]%c%c]%c%c}%c%c\n                                                 %c%c\"afasdfasf\"%c%c\n                                                 %c%c\"afasdfasf\"%c%c]%c%c\n                                           %c%c:bar%c %c\"fooz\"%c%c}%c\n           %c:uuid%c               %c#uuid %c%c\"4fe5d828-6444-11e8-822\"%c...%c%c\n           %c:atom/number%c        %cAtom<%c%c1%c%c>%c\n           %c:atom/record%c        %cAtom<%c%cFoos%c\n                               %c{%c%c:a%c %c1%c %c:b%c %c2%c%c}%c%c>%c\n           %c:map/multi-line%c     %c{%c%c:abc%c%c\n                                %c%c\"bar\"%c%c\n                                \n                                %c%c\"asdfasdfa\"%c%c\n                                %c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                \n                                %c%c[%c%c:a%c %c:b%c%c]%c%c\n                                %c%c123444%c%c}%c\n           %c:map/nested-meta%c    %c{%c %c    %c%c^{%c%c:a%c %cfoo%c %c    %c%c^{%c%c:abc%c %cbar%c%c\n                                                    %c%c:xyz%c %c\"abcdefghijklmnopqrstuvwxyzzzz\"%c...%c%c%c}%c%c}%c%c\n                                %c%ca%c %c    %c%c^{%c%c:abc%c %c\"bar\"%c%c %c%c:xyz%c %c\"abc\"%c%c}%c%c\n                                %c%cfoo%c %c    %c%c^{%c%c:abc%c %c\"bar\"%c%c %c%c:xyz%c %c\"abc\"%c%c}%c%c\n                                \n                                %c%c:b%c%c\n                                %c%c2%c%c}%c\n           %c:map/single-line%c    %c{%c%c:a%c %c1%c %c:b%c %c2%c %c:c%c %c\"three\"%c%c}%c\n           %c:set/multi-line%c     %c#{%c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                 %c%c3333333%c%c\n                                 %c%c:22222%c%c}%c\n           %c:set/single-line%c    %c#{%c%c1%c %c\"three\"%c %c:2%c%c}%c\n           %c:vector/multi-line%c  %c[%c%c\"abcdefghijklmnopqrstuvwxyzzz\"%c...%c%c%c\n                                %c%c:22222%c%c\n                                %c%c3333333%c%c]%c\n           %c:vector/single-line%c %c[%c%c1%c %c:2%c %c\"three\"%c%c]%c%c}%c%c}%c")))))
+                 "%c{%c%c:string%c           %c\"string\"%c\n %c:regex%c            %c#\"myregex\"%c\n %c:uuid%c             %c#uuid %c%c\"4fe5d828-6444-11e8-8222\"%c...%c%c\n %c:symbol%c           %cmysym%c\n %c:boolean%c          %ctrue%c\n %c:keyword%c          %c:keyword%c\n %c:nil%c              %cnil%c\n %c:##Nan%c            %cNaN%c\n %c:##Inf%c            %cInfinity%c\n %c:##-Inf%c           %c-Infinity%c\n %c:int%c              %c1234%c\n %c:float%c            %c3.33%c\n %c:lambda%c           %cλ%c%c%c%c[]%c\n %c:lambda-2-args%c    %cλ%c%c%c%c[%1 %2]%c\n %c:core-fn%c          %ccljs.core/juxt%c%c[var_args]%c\n %c:date-fn%c          %cjs/Date%c%c[]%c\n %c:datatype-class%c   %cfireworks.sample/MyType%c%c[a b]%c\n %c:recordtype-class%c %cfireworks.sample/MyRecordType%c%c[a b]%c\n %c:really-long-fn%c   %cxyasldfasldkfaslkjfzzzzzzz%c...%c%c%c[x y]%c\n %c:map%c              %c{%c%c:a%c %c1%c %c:b%c %c2%c %c:c%c %c\"three\"%c%c}%c%c\n ...               ...+22%c%c}%c")))))
 
 
 ;; TODO - Add tests for:

--- a/test/fireworks/core_test.cljc
+++ b/test/fireworks/core_test.cljc
@@ -14,13 +14,14 @@
 ;; Change it to that temporarily if you want to run these tests locally. This will be fixed in the near future.
 ;; By design, all cljs tests that test fireworks.core/p-data in this namespace will break if the line number that they are on changes!
 
+
 (def theme themes/alabaster-light-legacy)
 (declare escape-sgr)
 
 #?(:cljs
    (deftest p-data-basic 
      (is (=
-          (let [ret (? :data {:theme theme} "foo")] (!?pp 'p-data-basic ret))
+          (let [ret (? :data {:theme theme} "foo")] (?pp 'p-data-basic ret))
           {:quoted-form   "foo",
            :formatted     {:string     "%c\"foo\"%c",
                            :css-styles ["color:#448C27;line-height:1.45;"
@@ -44,7 +45,7 @@
 #?(:cljs
    (deftest p-data-with-label
      (is (= 
-          (let [ret (? :data "my-label" "foo")] (!?pp 'p-data-with-label ret))
+          (let [ret (? :data "my-label" "foo")] (?pp 'p-data-with-label ret))
           {:quoted-form   "foo",
            :formatted     {:string     "%c\"foo\"%c",
                            :css-styles ["color:#448C27;line-height:1.45;"
@@ -450,7 +451,7 @@
               #?(:clj
                  "〠38;5;241〠{〠0〠〠38;2;122;62;157〠:string〠0〠           〠38;2;68;140;39〠\"string\"〠0〠\n 〠38;2;122;62;157〠:regex〠0〠            〠38;2;68;140;39〠#\"myregex\"〠0〠\n 〠38;2;122;62;157〠:uuid〠0〠             〠3;38;2;57;137;98;48;2;238;251;238〠#uuid 〠0〠〠38;2;68;140;39〠\"4fe5d828-6444-11e8-8222\"〠3;38;2;140;140;140〠...〠0〠〠0〠\n 〠38;2;122;62;157〠:symbol〠0〠           〠38;2;77;109;186〠mysym〠0〠\n 〠38;2;122;62;157〠:symbol+meta〠0〠      〠38;2;77;109;186〠mysym〠0〠 〠38;2;190;85;187;48;2;250;232;253〠    〠0〠〠38;2;190;85;187;48;2;250;232;253〠^{〠0〠〠38;2;190;85;187;48;2;250;232;253〠:foo〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠\"bar\"〠0〠〠38;2;190;85;187;48;2;250;232;253〠}〠0〠\n 〠38;2;122;62;157〠:boolean〠0〠          〠38;2;122;62;157〠true〠0〠\n 〠38;2;122;62;157〠:keyword〠0〠          〠38;2;122;62;157〠:keyword〠0〠\n 〠38;2;122;62;157〠:nil〠0〠              〠38;2;122;62;157〠nil〠0〠\n 〠38;2;122;62;157〠:##Nan〠0〠            〠38;2;88;88;88〠NaN〠0〠\n 〠38;2;122;62;157〠:##Inf〠0〠            〠38;2;88;88;88〠Infinity〠0〠\n 〠38;2;122;62;157〠:##-Inf〠0〠           〠38;2;88;88;88〠-Infinity〠0〠\n 〠38;2;122;62;157〠:int〠0〠              〠38;2;122;62;157〠1234〠0〠\n 〠38;2;122;62;157〠:float〠0〠            〠38;2;122;62;157〠3.33〠0〠\n 〠38;2;122;62;157〠:lambda〠0〠           〠3;38;2;57;137;98;48;2;238;251;238〠λ〠0〠〠38;2;77;109;186〠〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:lambda-2-args〠0〠    〠3;38;2;57;137;98;48;2;238;251;238〠λ〠0〠〠38;2;77;109;186〠〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:core-fn〠0〠          〠38;2;77;109;186〠clojure.core/juxt〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:date-fn〠0〠          〠38;2;77;109;186〠java.util/Date〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:datatype-class〠0〠   〠38;2;77;109;186〠fireworks.sample/MyType〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:recordtype-class〠0〠 〠38;2;77;109;186〠fireworks.sample/MyRecordType〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:really-long-fn〠0〠   〠38;2;77;109;186〠xyasldfasldkfaslkjfzzzzzzzzzz〠3;38;2;140;140;140〠...〠0〠〠0〠〠38;2;153;153;153〠[]〠0〠〠3;38;2;140;140;140〠\n ...               ...+14〠0〠〠38;5;241〠}〠0〠"
                  :cljs
-                 "%c{%c%c:string%c           %c\"string\"%c\n %c:regex%c            %c#\"myregex\"%c\n %c:uuid%c             %c#uuid %c%c\"4fe5d828-6444-11e8-8222\"%c...%c%c\n %c:symbol%c           %cmysym%c\n %c:boolean%c          %ctrue%c\n %c:keyword%c          %c:keyword%c\n %c:nil%c              %cnil%c\n %c:##Nan%c            %cNaN%c\n %c:##Inf%c            %cInfinity%c\n %c:##-Inf%c           %c-Infinity%c\n %c:int%c              %c1234%c\n %c:float%c            %c3.33%c\n %c:lambda%c           %cλ%c%c%c%c[]%c\n %c:lambda-2-args%c    %cλ%c%c%c%c[%1 %2]%c\n %c:core-fn%c          %ccljs.core/juxt%c%c[var_args]%c\n %c:date-fn%c          %cjs/Date%c%c[]%c\n %c:datatype-class%c   %cfireworks.sample/MyType%c%c[a b]%c\n %c:recordtype-class%c %cfireworks.sample/MyRecordType%c%c[a b]%c\n %c:really-long-fn%c   %cxyasldfasldkfaslkjfzzzzzzz%c...%c%c%c[x y]%c\n %c:map%c              %c{%c%c:a%c %c1%c %c:b%c %c2%c %c:c%c %c\"three\"%c%c}%c%c\n ...               ...+16%c%c}%c")))))
+                 "%c{%c%c:string%c           %c\"string\"%c\n %c:regex%c            %c#\"myregex\"%c\n %c:uuid%c             %c#uuid %c%c\"4fe5d828-6444-11e8-8222\"%c...%c%c\n %c:symbol%c           %cmysym%c\n %c:symbol+meta%c      %cmysym%c %c    %c%c^{%c%c:foo%c %c\"bar\"%c%c}%c\n %c:boolean%c          %ctrue%c\n %c:keyword%c          %c:keyword%c\n %c:nil%c              %cnil%c\n %c:##Nan%c            %cNaN%c\n %c:##Inf%c            %cInfinity%c\n %c:##-Inf%c           %c-Infinity%c\n %c:int%c              %c1234%c\n %c:float%c            %c3.33%c\n %c:lambda%c           %cλ%c%c%c%c[]%c\n %c:lambda-2-args%c    %cλ%c%c%c%c[%1 %2]%c\n %c:core-fn%c          %ccljs.core/juxt%c%c[var_args]%c\n %c:date-fn%c          %cjs/Date%c%c[]%c\n %c:datatype-class%c   %cfireworks.sample/MyType%c%c[a b]%c\n %c:recordtype-class%c %cfireworks.sample/MyRecordType%c%c[a b]%c\n %c:really-long-fn%c   %cxyasldfasldkfaslkjfzzzzzzz%c...%c%c%c[x y]%c%c\n ...               ...+14%c%c}%c")))))
 
 
 ;; TODO - Add tests for:

--- a/test/fireworks/core_test.cljc
+++ b/test/fireworks/core_test.cljc
@@ -4,7 +4,6 @@
    [fireworks.core :refer [? !? ?> !?>]]
    [fireworks.config]
    [fireworks.pp :as pp :refer [?pp !?pp]]
-   [fireworks.smoke-test :as smoke-test]
    [fireworks.demo]
    [fireworks.themes :as themes] 
    [fireworks.sample :as sample] 
@@ -74,30 +73,30 @@
    :clj
    (do 
      #_(deftest  p-data-with-label-from-opts ;; line+column dependant
-       (is (= 
-            (let [ret              (? :data {:label                      "my-label"
-                                             :enable-terminal-truecolor? true
-                                             :enable-terminal-italics?   true
-                                             :bracket-contrast           "high"
-                                             :theme                      theme}
-                                      "foo")
-                  formatted-string (-> ret :formatted+ :string)]
+         (is (= 
+              (let [ret              (? :data {:label                      "my-label"
+                                               :enable-terminal-truecolor? true
+                                               :enable-terminal-italics?   true
+                                               :bracket-contrast           "high"
+                                               :theme                      theme}
+                                        "foo")
+                    formatted-string (-> ret :formatted+ :string)]
               ;; (pp/pprint (escape-sgr formatted-string))
-              (string/join (escape-sgr formatted-string)))
-            "〠3;38;2;77;109;186;48;2;237;242;252〠my-label〠0〠  〠3;38;2;77;109;186〠fireworks.core-test:266:36〠0〠〠〠 \n〠0〠〠38;2;68;140;39〠\"foo\"〠0〠")))
+                (string/join (escape-sgr formatted-string)))
+              "〠3;38;2;77;109;186;48;2;237;242;252〠my-label〠0〠  〠3;38;2;77;109;186〠fireworks.core-test:266:36〠0〠〠〠 \n〠0〠〠38;2;68;140;39〠\"foo\"〠0〠")))
 
      #_(deftest p-data-with-label-from-opts-primitive-terminal-emulator ;; line+column dependant
-       (is (= 
-            (let [ret              (? :data {:label                      "my-label"
-                                             :enable-terminal-truecolor? false
-                                             :enable-terminal-italics?   false
-                                             :bracket-contrast           "high"
-                                             :theme                      theme}
-                                      "foo")
-                  formatted-string (-> ret :formatted+ :string)]
+         (is (= 
+              (let [ret              (? :data {:label                      "my-label"
+                                               :enable-terminal-truecolor? false
+                                               :enable-terminal-italics?   false
+                                               :bracket-contrast           "high"
+                                               :theme                      theme}
+                                        "foo")
+                    formatted-string (-> ret :formatted+ :string)]
               ;; (pp/pprint (escape-sgr formatted-string))
-              (string/join (escape-sgr formatted-string)))
-            "〠38;5;61;48;5;255〠my-label〠0〠  〠38;5;61〠fireworks.core-test:279:36〠0〠〠〠 \n〠0〠〠38;5;64〠\"foo\"〠0〠")))
+                (string/join (escape-sgr formatted-string)))
+              "〠38;5;61;48;5;255〠my-label〠0〠  〠38;5;61〠fireworks.core-test:279:36〠0〠〠〠 \n〠0〠〠38;5;64〠\"foo\"〠0〠")))
 
      (deftest p-data-with-non-coll-level-1-depth-length-limit
        (is (= 
@@ -177,7 +176,7 @@
                                              :enable-terminal-italics?   true
                                              :bracket-contrast           "high"
                                              :theme                      theme}
-                                      (atom smoke-test/my-record-type))
+                                      (atom sample/my-record-type))
                   formatted-string (-> ret :formatted :string)
                   escaped          (string/join (escape-sgr formatted-string))]
               #_(?pp 'p-data-record-sample-in-atom escaped)
@@ -191,7 +190,7 @@
                                              :enable-terminal-italics?   true
                                              :bracket-contrast           "high"
                                              :theme                      theme}
-                                      smoke-test/my-record-type)
+                                      sample/my-record-type)
                   formatted-string (-> ret :formatted :string)
                   escaped          (string/join (escape-sgr formatted-string))]
               #_(?pp 'p-data-record-sample escaped)
@@ -370,7 +369,22 @@
               ;; (pp/pprint 'java-util-arraylist)
               ;; (pp/pprint (escape-sgr formatted-string))
               (string/join (escape-sgr formatted-string)))
-            (str "〠3;38;2;57;137;98;48;2;238;251;238〠" "java.util.ArrayList" "〠0〠" "\n" "〠38;5;241;48;2;238;251;238〠" "[" "〠0〠" "〠38;2;122;62;157〠" "1" "〠0〠" " " "〠38;2;122;62;157〠" "2" "〠0〠" " " "〠38;2;122;62;157〠" "3" "〠0〠" "〠38;5;241;48;2;238;251;238〠" "]" "〠0〠"))))))
+            (str "〠3;38;2;57;137;98;48;2;238;251;238〠" "java.util.ArrayList" "〠0〠" "\n" "〠38;5;241;48;2;238;251;238〠" "[" "〠0〠" "〠38;2;122;62;157〠" "1" "〠0〠" " " "〠38;2;122;62;157〠" "2" "〠0〠" " " "〠38;2;122;62;157〠" "3" "〠0〠" "〠38;5;241;48;2;238;251;238〠" "]" "〠0〠"))))
+
+     (deftest java-interop-types
+       (is (= 
+            (let [ret              (? :data
+                                      {:coll-limit 100
+                                       :label      "JVM Clojure Values"}
+                                      sample/interop-types)
+                  formatted-string (-> ret :formatted :string)
+                  escaped          (string/join (escape-sgr formatted-string))]
+              ;; (pp/pprint 'java-util-arraylist)
+              ;; (pp/pprint (escape-sgr formatted-string))
+              (!?pp 'java-interop-types escaped))
+            "〠38;5;241〠{〠0〠〠38;2;68;140;39〠\"Java collection types\"〠0〠 〠38;5;32〠{〠0〠〠38;2;122;62;157〠:java.util.ArrayList〠0〠 〠3;38;2;199;104;35;48;2;255;249;245〠java.util.ArrayList〠0〠\n                                               〠38;5;208;48;2;255;249;245〠[〠0〠〠38;2;122;62;157〠0〠0〠 〠38;2;122;62;157〠1〠0〠 〠38;2;122;62;157〠2〠0〠 〠38;2;122;62;157〠3〠0〠 〠38;2;122;62;157〠4〠0〠 〠38;2;122;62;157〠5〠0〠〠38;5;208;48;2;255;249;245〠]〠0〠\n                          〠38;2;122;62;157〠:java.util.HashMap〠0〠   〠3;38;2;199;104;35;48;2;255;249;245〠java.util.HashMap〠0〠\n                                               〠38;5;208;48;2;255;249;245〠{〠0〠〠38;2;68;140;39〠\"a\"〠0〠 〠38;2;122;62;157〠1〠0〠 〠38;2;68;140;39〠\"b\"〠0〠 〠38;2;122;62;157〠2〠0〠〠38;5;208;48;2;255;249;245〠}〠0〠\n                          〠38;2;122;62;157〠:java.util.HashSet〠0〠   〠3;38;2;199;104;35;48;2;255;249;245〠java.util.HashSet〠0〠\n                                               〠38;5;208;48;2;255;249;245〠#{〠0〠〠38;2;122;62;157〠1〠0〠 〠38;2;68;140;39〠\"a\"〠0〠 〠38;2;122;62;157〠2〠0〠 〠38;2;68;140;39〠\"b\"〠0〠〠38;5;208;48;2;255;249;245〠}〠0〠\n                          〠38;2;122;62;157〠:java.lang.String〠0〠    〠38;2;68;140;39〠\"welcome\"〠0〠\n                          〠38;2;122;62;157〠:array〠0〠               〠3;38;2;199;104;35;48;2;255;249;245〠Ljava.lang.Object〠0〠\n                                               〠38;5;208;48;2;255;249;245〠[〠0〠〠38;2;122;62;157〠1〠0〠 〠38;2;122;62;157〠2〠0〠 〠38;2;122;62;157〠3〠0〠 〠38;2;122;62;157〠4〠0〠 〠38;2;122;62;157〠5〠0〠〠38;5;208;48;2;255;249;245〠]〠0〠〠38;5;32〠}〠0〠\n 〠38;2;68;140;39〠\"Java numbers\"〠0〠          〠38;5;32〠{〠0〠〠38;2;122;62;157〠:ratio〠0〠               〠38;2;122;62;157〠1/3〠0〠\n                          〠38;2;122;62;157〠:byte〠0〠                〠38;2;122;62;157〠0〠0〠\n                          〠38;2;122;62;157〠:short〠0〠               〠38;2;122;62;157〠3〠0〠\n                          〠38;2;122;62;157〠:double〠0〠              〠38;2;122;62;157〠23.44〠0〠\n                          〠38;2;122;62;157〠:decimal〠0〠             〠38;2;122;62;157〠1〠0〠\n                          〠38;2;122;62;157〠:int〠0〠                 〠38;2;122;62;157〠1〠0〠\n                          〠38;2;122;62;157〠:float〠0〠               〠38;2;122;62;157〠1.5〠0〠\n                          〠38;2;122;62;157〠:char〠0〠                〠38;2;88;88;88〠a〠0〠\n                          〠38;2;122;62;157〠:java.math.BigInt〠3;38;2;140;140;140〠...〠0〠〠0〠 〠38;2;122;62;157〠171〠0〠〠38;5;32〠}〠0〠〠38;5;241〠}〠0〠")))
+     
+     ))
 
 (defn- escape-sgr
   "Escape sgr codes so we can test clj output."
@@ -387,16 +401,16 @@
 
 ;; Basic print-and-return tests, cljc
 (do
-  ;; (deftest ?-par-result
-  ;;   (is (= (? :result "par?") "par?")))
-  ;; (deftest ?-par
-  ;;   (is (= (? "par?") "par?")))
-  ;; (deftest !?-par
-  ;;   (is (= (!? "par?") "par?")))
-  ;; (deftest ?>-par
-  ;;   (is (= (?> "par?") "par?")))
-  ;; (deftest !?>-par
-  ;;   (is (= (!?> "par?") "par?")))
+  (deftest ?-par-result
+    (is (= (? :result "par?") "par?")))
+  (deftest ?-par
+    (is (= (? "par?") "par?")))
+  (deftest !?-par
+    (is (= (!? "par?") "par?")))
+  (deftest ?>-par
+    (is (= (?> "par?") "par?")))
+  (deftest !?>-par
+    (is (= (!?> "par?") "par?")))
 
   (deftest p-data-basic-samples
          (is (= 
@@ -432,11 +446,11 @@
                        :clj
                        (string/join (escape-sgr (-> ret :formatted :string))))]
                 #?(:clj (do (!?pp 'p-data-basic-samples formatted-string))
-                   :cljs (do (!?pp 'p-data-basic-samples formatted-string))))
+                   :cljs (do (?pp 'p-data-basic-samples formatted-string))))
               #?(:clj
-                 "〠38;5;241〠{〠0〠〠38;2;122;62;157〠:string〠0〠           〠38;2;68;140;39〠\"string\"〠0〠\n 〠38;2;122;62;157〠:regex〠0〠            〠38;2;68;140;39〠#\"myregex\"〠0〠\n 〠38;2;122;62;157〠:uuid〠0〠             〠3;38;2;57;137;98;48;2;238;251;238〠#uuid 〠0〠〠38;2;68;140;39〠\"4fe5d828-6444-11e8-8222\"〠3;38;2;140;140;140〠...〠0〠〠0〠\n 〠38;2;122;62;157〠:symbol〠0〠           〠38;2;77;109;186〠mysym〠0〠\n 〠38;2;122;62;157〠:boolean〠0〠          〠38;2;122;62;157〠true〠0〠\n 〠38;2;122;62;157〠:keyword〠0〠          〠38;2;122;62;157〠:keyword〠0〠\n 〠38;2;122;62;157〠:nil〠0〠              〠38;2;122;62;157〠nil〠0〠\n 〠38;2;122;62;157〠:##Nan〠0〠            〠38;2;122;62;157〠NaN〠0〠\n 〠38;2;122;62;157〠:##Inf〠0〠            〠38;2;122;62;157〠Infinity〠0〠\n 〠38;2;122;62;157〠:##-Inf〠0〠           〠38;2;122;62;157〠-Infinity〠0〠\n 〠38;2;122;62;157〠:int〠0〠              〠38;2;122;62;157〠1234〠0〠\n 〠38;2;122;62;157〠:float〠0〠            〠38;2;122;62;157〠3.33〠0〠\n 〠38;2;122;62;157〠:lambda〠0〠           〠3;38;2;57;137;98;48;2;238;251;238〠λ〠0〠〠38;2;77;109;186〠〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:lambda-2-args〠0〠    〠3;38;2;57;137;98;48;2;238;251;238〠λ〠0〠〠38;2;77;109;186〠〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:core-fn〠0〠          〠38;2;77;109;186〠clojure.core/juxt〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:date-fn〠0〠          〠38;2;77;109;186〠java.util/Date〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:datatype-class〠0〠   〠38;2;77;109;186〠fireworks.sample/MyType〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:recordtype-class〠0〠 〠38;2;77;109;186〠fireworks.sample/MyRecordType〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:really-long-fn〠0〠   〠38;2;77;109;186〠xyasldfasldkfaslkjfzzzzzzzzzz〠3;38;2;140;140;140〠...〠0〠〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:map〠0〠              〠38;5;32〠{〠0〠〠38;2;122;62;157〠:a〠0〠 〠38;2;122;62;157〠1〠0〠 〠38;2;122;62;157〠:b〠0〠 〠38;2;122;62;157〠2〠0〠 〠38;2;122;62;157〠:c〠0〠 〠38;2;68;140;39〠\"three\"〠0〠〠38;5;32〠}〠0〠〠3;38;2;140;140;140〠\n ...               ...+22〠0〠〠38;5;241〠}〠0〠"
+                 "〠38;5;241〠{〠0〠〠38;2;122;62;157〠:string〠0〠           〠38;2;68;140;39〠\"string\"〠0〠\n 〠38;2;122;62;157〠:regex〠0〠            〠38;2;68;140;39〠#\"myregex\"〠0〠\n 〠38;2;122;62;157〠:uuid〠0〠             〠3;38;2;57;137;98;48;2;238;251;238〠#uuid 〠0〠〠38;2;68;140;39〠\"4fe5d828-6444-11e8-8222\"〠3;38;2;140;140;140〠...〠0〠〠0〠\n 〠38;2;122;62;157〠:symbol〠0〠           〠38;2;77;109;186〠mysym〠0〠\n 〠38;2;122;62;157〠:symbol+meta〠0〠      〠38;2;77;109;186〠mysym〠0〠 〠38;2;190;85;187;48;2;250;232;253〠    〠0〠〠38;2;190;85;187;48;2;250;232;253〠^{〠0〠〠38;2;190;85;187;48;2;250;232;253〠:foo〠0〠〠38;2;190;85;187;48;2;250;232;253〠 〠0〠〠38;2;190;85;187;48;2;250;232;253〠\"bar\"〠0〠〠38;2;190;85;187;48;2;250;232;253〠}〠0〠\n 〠38;2;122;62;157〠:boolean〠0〠          〠38;2;122;62;157〠true〠0〠\n 〠38;2;122;62;157〠:keyword〠0〠          〠38;2;122;62;157〠:keyword〠0〠\n 〠38;2;122;62;157〠:nil〠0〠              〠38;2;122;62;157〠nil〠0〠\n 〠38;2;122;62;157〠:##Nan〠0〠            〠38;2;88;88;88〠NaN〠0〠\n 〠38;2;122;62;157〠:##Inf〠0〠            〠38;2;88;88;88〠Infinity〠0〠\n 〠38;2;122;62;157〠:##-Inf〠0〠           〠38;2;88;88;88〠-Infinity〠0〠\n 〠38;2;122;62;157〠:int〠0〠              〠38;2;122;62;157〠1234〠0〠\n 〠38;2;122;62;157〠:float〠0〠            〠38;2;122;62;157〠3.33〠0〠\n 〠38;2;122;62;157〠:lambda〠0〠           〠3;38;2;57;137;98;48;2;238;251;238〠λ〠0〠〠38;2;77;109;186〠〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:lambda-2-args〠0〠    〠3;38;2;57;137;98;48;2;238;251;238〠λ〠0〠〠38;2;77;109;186〠〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:core-fn〠0〠          〠38;2;77;109;186〠clojure.core/juxt〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:date-fn〠0〠          〠38;2;77;109;186〠java.util/Date〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:datatype-class〠0〠   〠38;2;77;109;186〠fireworks.sample/MyType〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:recordtype-class〠0〠 〠38;2;77;109;186〠fireworks.sample/MyRecordType〠0〠〠38;2;153;153;153〠[]〠0〠\n 〠38;2;122;62;157〠:really-long-fn〠0〠   〠38;2;77;109;186〠xyasldfasldkfaslkjfzzzzzzzzzz〠3;38;2;140;140;140〠...〠0〠〠0〠〠38;2;153;153;153〠[]〠0〠〠3;38;2;140;140;140〠\n ...               ...+14〠0〠〠38;5;241〠}〠0〠"
                  :cljs
-                 "%c{%c%c:string%c           %c\"string\"%c\n %c:regex%c            %c#\"myregex\"%c\n %c:uuid%c             %c#uuid %c%c\"4fe5d828-6444-11e8-8222\"%c...%c%c\n %c:symbol%c           %cmysym%c\n %c:boolean%c          %ctrue%c\n %c:keyword%c          %c:keyword%c\n %c:nil%c              %cnil%c\n %c:##Nan%c            %cNaN%c\n %c:##Inf%c            %cInfinity%c\n %c:##-Inf%c           %c-Infinity%c\n %c:int%c              %c1234%c\n %c:float%c            %c3.33%c\n %c:lambda%c           %cλ%c%c%c%c[]%c\n %c:lambda-2-args%c    %cλ%c%c%c%c[%1 %2]%c\n %c:core-fn%c          %ccljs.core/juxt%c%c[var_args]%c\n %c:date-fn%c          %cjs/Date%c%c[]%c\n %c:datatype-class%c   %cfireworks.sample/MyType%c%c[a b]%c\n %c:recordtype-class%c %cfireworks.sample/MyRecordType%c%c[a b]%c\n %c:really-long-fn%c   %cxyasldfasldkfaslkjfzzzzzzz%c...%c%c%c[x y]%c\n %c:map%c              %c{%c%c:a%c %c1%c %c:b%c %c2%c %c:c%c %c\"three\"%c%c}%c%c\n ...               ...+22%c%c}%c")))))
+                 "%c{%c%c:string%c           %c\"string\"%c\n %c:regex%c            %c#\"myregex\"%c\n %c:uuid%c             %c#uuid %c%c\"4fe5d828-6444-11e8-8222\"%c...%c%c\n %c:symbol%c           %cmysym%c\n %c:boolean%c          %ctrue%c\n %c:keyword%c          %c:keyword%c\n %c:nil%c              %cnil%c\n %c:##Nan%c            %cNaN%c\n %c:##Inf%c            %cInfinity%c\n %c:##-Inf%c           %c-Infinity%c\n %c:int%c              %c1234%c\n %c:float%c            %c3.33%c\n %c:lambda%c           %cλ%c%c%c%c[]%c\n %c:lambda-2-args%c    %cλ%c%c%c%c[%1 %2]%c\n %c:core-fn%c          %ccljs.core/juxt%c%c[var_args]%c\n %c:date-fn%c          %cjs/Date%c%c[]%c\n %c:datatype-class%c   %cfireworks.sample/MyType%c%c[a b]%c\n %c:recordtype-class%c %cfireworks.sample/MyRecordType%c%c[a b]%c\n %c:really-long-fn%c   %cxyasldfasldkfaslkjfzzzzzzz%c...%c%c%c[x y]%c\n %c:map%c              %c{%c%c:a%c %c1%c %c:b%c %c2%c %c:c%c %c\"three\"%c%c}%c%c\n ...               ...+16%c%c}%c")))))
 
 
 ;; TODO - Add tests for:

--- a/test/fireworks/script_test.cljc
+++ b/test/fireworks/script_test.cljc
@@ -1,7 +1,7 @@
 (ns fireworks.script-test
   (:require [fireworks.core :refer [? !? ?> !?>]]
-            [fireworks.smoke-test :as smoke-test]))
+            [fireworks.sample]))
 
 (defn main [& cli-args]
   (? "testing from node or deno script"
-     smoke-test/basic-samples-cljc))
+     fireworks.sample/array-map-of-everything-cljc))

--- a/test/fireworks/script_test.cljc
+++ b/test/fireworks/script_test.cljc
@@ -1,0 +1,7 @@
+(ns fireworks.script-test
+  (:require [fireworks.core :refer [? !? ?> !?>]]
+            [fireworks.smoke-test :as smoke-test]))
+
+(defn main [& cli-args]
+  (? "testing from node or deno script"
+     smoke-test/basic-samples-cljc-theme))

--- a/test/fireworks/script_test.cljc
+++ b/test/fireworks/script_test.cljc
@@ -4,4 +4,4 @@
 
 (defn main [& cli-args]
   (? "testing from node or deno script"
-     smoke-test/basic-samples-cljc-theme))
+     smoke-test/basic-samples-cljc))

--- a/test/fireworks/smoke_test.cljc
+++ b/test/fireworks/smoke_test.cljc
@@ -1114,14 +1114,16 @@ basic-samples
 ;;     ;;  (? #{"a" 1 "b" 2})                        
      
 
-    (println "\n:Java HashSet")
-    (? (java.util.HashSet. #{"a" 1 "b" 2}))
-     
-    (println "\n:Java ArrayList")
-    (? (java.util.ArrayList. [1 2 3 4 5 6 7]))
 
-    (println "\n:Java HashMap")
-    (println (? :data {:theme "Monokai Dark"} (java.util.HashMap. {"a" 1 "b" 2 "c" 3})))
+    ;; (println "\n:Java HashSet")
+    ;; (? (java.util.HashSet. #{"a" 1 "b" 2}))
+     
+    ;; (println "\n:Java ArrayList")
+    ;; (? (java.util.ArrayList. [1 2 3 4 5 6 7]))
+
+    ;; (println "\n:Java HashMap")
+    ;; (println (? :data {:theme "Monokai Dark"} (java.util.HashMap. {"a" 1 "b" 2 "c" 3})))
+
 
     ;;  (? [1 2 3 4 5 6 7])
     ;;  (? :result 

--- a/test/fireworks/smoke_test.cljc
+++ b/test/fireworks/smoke_test.cljc
@@ -4,6 +4,7 @@
   (:require [fireworks.core :refer [? !? ?> !?>]]
             [fireworks.themes :as themes]
             [bling.core :refer [callout bling ?sgr]]
+            [bling.sample]
             [clojure.string :as string]
             [fireworks.pp :as pp]
             [clojure.pprint :refer [pprint]]
@@ -69,6 +70,7 @@
     :label      "JVM Clojure Values with extras"}
     sample/vec-of-interop-types-with-extras)
 
+(bling.sample/sample)
 
 
 

--- a/test/fireworks/smoke_test.cljc
+++ b/test/fireworks/smoke_test.cljc
@@ -45,8 +45,6 @@
  :find                         nil}
 
 
-;; Formatting
-
 (deftype MyType [a b])
 (def my-data-type (->MyType 2 3))
 (defrecord MyRecordType [a b])
@@ -59,108 +57,124 @@
 (defn xyv ([x y] (+ x y)) ([x y v] (+ x y v)))
 (defn xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz [x y] (+ x y))
 
-#?(:cljs
-   (do
-     (do
-         (def my-date (new js/Date))
-         (def my-prom (js/Promise. (fn [x] x)))
-         (def prom-ref js/Promise)
 
-         (def cljs-datatypes
-           [my-data-type
-            my-record-type])
+(def my-date (new #?(:cljs js/Date :clj java.util.Date)))
 
-         (def cljs-functions
-           [MyType
-            MyRecordType
-            different-behavior
-            xy
-            xyv
-            xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz
-            #(inc %)
-            (fn [a] (inc a))
-            (fn incr [a] (inc a))
-            juxt
-            js/Date
-            js/Array])
+        ;;  (def my-prom (js/Promise. (fn [x] x)))
+        ;;  (def prom-ref js/Promise)
 
-         (def js-number-types
-           {##NaN      ##NaN
-            ##Inf      ##Inf
-            ##-Inf     ##-Inf
-            :js/BigInt (js/BigInt 171)
-            :int       1
-            :float     1.50})))
-   :clj
-   (do
-    (def my-date (java.util.Date.))
-     (def number-types
-       {:nan                  ##NaN
-        :inf                  ##Inf
-        :-Inf                 ##-Inf
-        1/3                   1/3
-        :byte                 (byte 0)
-        :short                (short 3)
-        :double               (double 23.44)
-        :decimal              1M
-        :int                  1
-        :float                (float 1.50)
-        :char                 (char 97)
-        :java.math.BigInteger (java.math.BigInteger. "171")})))
+(def number-types 
+  #?(:cljs
+     {##NaN      ##NaN
+      ##Inf      ##Inf
+      ##-Inf     ##-Inf
+      :js/BigInt (js/BigInt 171)
+      :int       1
+      :float     1.50}
+     :clj
+     {:not-a-number       ##NaN
+      :infinity           ##Inf
+      :negative-infinity  ##-Inf
+      :fraction           1/3
+      :byte               (byte 0)
+      :short              (short 3)
+      :double             (double 23.44)
+      :decimal            1M
+      :int                1
+      :float              (float 1.50)
+      :char               (char 97)
+      :BigInteger         (java.math.BigInteger. "171")}))
 
 (def everything
-  {:primitives   {:a                              9999
-                  :bbb                            "asdfasdfasdfjasdfasdfasdfasdfa"
-                  "really-long-string-abcdefghi"  "really-long-string-abcdefghi"  
-                  1                               2
-                  "string"                        "hello"
-                  :keyword                        :keyword
-                  true                            false
-                  nil                             nil
-                  'symbol                         'symbol
-                  #"^hi$"                         #"^hi$"
-                  #"really-long-string-abcdefghi" #"really-long-string-abcdefghi"}
-   :functions    {(symbol "(fn [])")   #()
-                  (symbol "#(+ % %2)") #(+ % %2) 
-                  +                    -
-                  MyType               MyType
-                  my-data-type         my-data-type
-                  MyRecordType         MyRecordType
-                  :really-long         xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz}
-   :collections  {:vector        [1 2 3]
-                  :set           #{1 2 3}
-                  :list          '(1 2 3)
-                  :seq           (range 10)
-                  :record        my-record-type
-                  ;; :truncation-candidate [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23]
-                  :colls-as-keys {[1 2]    "afjasljfalsjdalsfk"
-                                  #{1 2 3} "afsdfasdfsdfasfas"}}
-   :abstractions {:atom (atom 1)
-                  :date my-date}
-   :with-meta    {:symbol  (with-meta (symbol (str "foo"))
-                             (into {}
-                                   (map (fn [x y] [x y])
-                                        (range 20)
-                                        (repeat :foo))))
-                  :vector  ^{:foo :bar} [:foo :bar :baz]
-                  :vector* ^{:foo :bar} [(with-meta (symbol (str "foo"))
-                                           {:bar :baz})
-                                         (with-meta (symbol (str "bar")) 
-                                           {:bar :baz})
-                                         (with-meta (symbol (str "baz"))
-                                           {:bar :baz})]
-                  :map     ^{:foo :bar} {:one :two}
-                  :map*    ^{:foo :bar} {(with-meta (symbol (str "foo"))
-                                           {:bar :baz})
-                                         (with-meta (symbol (str "bar"))
-                                           {:bar :baz})
+  (array-map
+   :primitives
+   {:string   "string"
+    :uuid     #uuid "4fe5d828-6444-11e8-8222-720007e40350"
+    :int      1234
+    :float    3.33
+    :fraction 1/3
+    :symbol   'mysym
+    :boolean  true
+    :keyword  :keyword
+    :nil      nil}
 
-                                         (with-meta (symbol (str "bang"))
-                                           {:bar :baz})
-                                         (with-meta (symbol (str "bop"))
-                                           {:bar :baz})}}
-   :number-types #?(:cljs js-number-types
-                    :clj nil)})
+   :number-types
+   number-types
+
+   :functions    
+   {:lambda            #()
+    :lambda-2-args     #(+ % %2) 
+    :core-fn           juxt 
+    :interop-date-fn   #?(:cljs
+                          js/Date
+                          :clj
+                          java.util.Date)
+    :datatype-constr   MyType
+    :recordtype-constr MyRecordType
+    :really-long-fn    xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz}
+
+   :collections  
+   {:vector    [1 2 3]
+    :set       #{1 2 3}
+    :list      '(1 2 3)
+    :lazy-seq  (range 10)
+    :record    my-record-type
+    :array-map (apply array-map
+                      (mapcat (fn [x y] [x y])
+                              (range 12)
+                              (range 12)))
+    ;; :truncation-candidate [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23]
+    }
+
+   :map-keys   
+   {+                              "core function"
+    "really-long-string-abcdefghi" "really-long-string-abcdefghi"
+    [1 2]                          "vector"
+    #{1 2 3}                       "set"
+    'symbol                        "symbol"
+    (with-meta 'mysym
+      {:a "foo"
+       :b [1 2 [1 2 3 4]]})        "symbol with meta"
+    #"^hi$"                        "regex"
+    #"really-long-regex-abcdefghi" "long regex"
+    1                              "number" 
+    nil                            "nil" 
+                ;; MyType               MyType
+                ;; my-data-type         my-data-type
+                ;; MyRecordType         MyRecordType
+                ;; :really-long         xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz
+    }
+
+   :abstractions
+   {:atom      (atom 1)
+    :date      my-date
+    :volatile! (volatile! 1)
+    }
+
+   :with-meta
+   {:symbol  (with-meta (symbol (str "foo"))
+               (apply array-map
+                     (mapcat (fn [x y] [x y])
+                             (range 7)
+                             (repeat :foo))))
+    :vector  ^{:foo :bar} [:foo :bar :baz]
+    :vector* ^{:foo :bar} [(with-meta (symbol (str "foo"))
+                             {:bar :baz})
+                           (with-meta (symbol (str "bar")) 
+                             {:bar :baz})
+                           (with-meta (symbol (str "baz"))
+                             {:bar :baz})]
+    :map     ^{:foo :bar} {:one :two}
+    :map*    ^{:foo :bar} {(with-meta (symbol (str "foo"))
+                             {:bar :baz})  (with-meta (symbol (str "bar"))
+                                             {:bar :baz})
+
+                           (with-meta (symbol (str "bang"))
+                             {:bar :baz}) (with-meta (symbol (str "bop"))
+                                            {:bar :baz})}}
+))
+
+(? everything)
 
 (defrecord Foos [a b])
 

--- a/test/fireworks/smoke_test.cljc
+++ b/test/fireworks/smoke_test.cljc
@@ -15,12 +15,6 @@
             #?(:cljs [cljs.test :refer [deftest is]])
             #?(:clj [clojure.test :refer :all])))
 
-(def theme themes/alabaster-light)
-
-;; testing label length
-;; (? (str "asdfasdfasdfasdfadsfasfasdf" "zzzzzzzzzzzzz" "xxxxxxx"))
-
-;; (array-map "one" 1 "two" 2 "three" 3 "four" 4 "five" 5 "six" 6 "seven" 7 "eight" 8 "nine" 9)
 
 ;; This is example config. If you want to run fireworks.core-test tests locally,
 ;; replace the config map in your ~/.fireworks/config.edn with this map temporarily.
@@ -45,182 +39,38 @@
  :custom-printers              nil
  :find                         nil}
 
-
-(deftype MyType [a b])
-(def my-data-type (->MyType 2 3))
-(defrecord MyRecordType [a b])
-(def my-record-type (->MyRecordType "a" "b"))
-(defmulti different-behavior (fn [x] (:x-type x)))
-(defmethod different-behavior :wolf
-  [x]
-  (str (:name x) " will have a specific behavior"))
-(defn xy [x y] (+ x y))
-(defn xyv ([x y] (+ x y)) ([x y v] (+ x y v)))
-(defn xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz [x y] (+ x y))
-(def my-date (new #?(:cljs js/Date :clj java.util.Date)))
-
-;;  (def my-prom (js/Promise. (fn [x] x)))
-;;  (def prom-ref js/Promise)
+;; Todo - the slice samplings such as sample/array-map-of-everything-cljc
+;; fns so you can pass ks for get-in an narrowing 
+#_(pprint (tag-map 1/3))
 
 
-;; For producing example :call field in metadata of examples
-(defrecord QuotedCall [qx x])
 
-#?(:clj
-   (do (defn tt*
-         [x
-          {:keys [show-extras?
-                  show-extras-as-meta?
-                  extras-keys]}]
-         (let [[x call] (if (instance? QuotedCall x)
-                          [(:x x) (:qx x)]
-                          [x nil])
-               extras   (when show-extras?
-                          (merge (tag-map x)
-                                 (when call {:call call})))
-               extras   (or (some->> extras-keys
-                                     seq
-                                     (select-keys extras))
-                            extras)
-               x        (if (and show-extras?
-                                 show-extras-as-meta?)
-                          (if (util/carries-meta? x)
-                            x
-                            (-> x str symbol))
-                          x)]
-           (cond (and show-extras?
-                      show-extras-as-meta?)
-                 (with-meta x extras)
-
-                 show-extras?
-                 [x extras]
-
-                 :else
-                 x)))
-       
-       (defmacro qc [coll]
-         `(do
-            (->QuotedCall (quote ~coll) ~coll))
-         )))
-
-(def interop-collection-types
-#?(:cljs
-   ()
-   :clj
-   (array-map 
-    :java.util.ArrayList (java.util.ArrayList. (range 6))
-    :java.util.HashMap (java.util.HashMap. {"a" 1
-                                            "b" 2})
-    :java.util.HashSet (java.util.HashSet. #{"a" 1 "b" 2})
-    :java.lang.String (java.lang.String. "welcome")
-    :array (to-array '(1 2 3 4 5)))))
-
-(def number-types 
-  #?(:cljs
-     (array-map
-      :not-a-number      ##NaN
-      :infinity      ##Inf
-      :negative-infinity     ##-Inf
-      :js/BigInt (js/BigInt 171)
-      :int       1
-      :float     1.50)
-     :clj
-     (array-map
-      :fraction           1/3
-      :byte               (byte 0)
-      :short              (short 3)
-      :double             (double 23.44)
-      :decimal            1M
-      :int                1
-      :float              (float 1.50)
-      :char               (char 97)
-      :java/BigInteger         (java.math.BigInteger. "171"))))
-
-(pprint (? :data "foo"))
+(? {:coll-limit 100
+    :theme      "Alabaster Light"
+    :label      "Clojure(Script) Values"}
+   sample/array-map-of-everything-cljc)
 
 (!? {:coll-limit 100
     :theme      "Alabaster Light"
-    :label      "Clojure(Script) Values"
-    :find {:pred #(= :tag %)}}
-     sample/vec-of-everything-cljc-with-extras)
+    :label      "Clojure(Script) Values"}
+   sample/array-map-of-multiline-formatting-cljc)
 
 (!? {:coll-limit 100
-    :label      "JVM Clojure Values"}
-   sample/interop-collection-types
-   #_(sample/show-everything [:number-types
-                            :interop-collection-types] 
-                           {:as-vec?     false
-                            ;;  :show-extras?         true
-                            ;;  :show-extras-as-meta? true
-                            :extras-keys [#_:tag
-                                          #_:call
-                                          :all-tags]}))
+    :theme      "Alabaster Light"
+    :label      "Clojure(Script) Values, with extras"
+    :find {:pred #(= :tag %)}}
+     (sample/vec-of-everything-cljc-with-extras))
 
-(def basic-samples-cljc 
-  {:string             "string"
-   :uuid               #uuid "4fe5d828-6444-11e8-8222-720007e40350"
-   :number             1234
-   :symbol             (with-meta 'mysym {:foo :bar})
-   :symbol2            (with-meta 'mysym
-                         {:foo ["afasdfasf"
-                                "afasdfasf"
-                                {:a "foo"
-                                 :b [1 2 [1 2 3 4]]}
-                                "afasdfasf"
-                                "afasdfasf"]
-                          :bar "fooz"})
-   :boolean            true
-   :lambda              #(inc %)
-   :fn                 juxt
-   :regex              #"^hi$"
-   :record             my-record-type
-   :atom/record        (atom my-record-type)
-   :atom/number        (atom 1)
-   :brackets           [[[[[[]]]]]]
+(!? {:coll-limit 100
+     :label      "JVM Clojure Values"}
+    sample/interop-types)
 
-   :map/nested-meta    (with-meta 
-                         {(with-meta (symbol :a)
-                            {:abc "bar"
-                             :xyz "abc"}) (with-meta (symbol "foo")
-                                            {:abc "bar"
-                                             :xyz "abc"})
-                          :b                                        2}
-                         {:a (with-meta (symbol "foo")
-                               {:abc (symbol "bar")
-                                :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})})
-   :map/single-line    {:a 1
-                        :b 2
-                        :c "three"}
-   :map/multi-line     {:abc      "bar"
-                        "asdfasdfa" "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-                        [:a :b]   123444}
-   :vector/single-line [1 :2 "three"]
-   :vector/multi-line  ["abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-                        :22222
-                        3333333]
-   :set/single-line    #{1 :2 "three"}
-   :set/multi-line     #{"abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-                         :22222
-                         3333333}
-   })
+(!? {:coll-limit 100
+    :label      "JVM Clojure Values with extras"}
+    sample/vec-of-interop-types-with-extras)
 
-(def basic-samples-cljc-theme
-  {:string        "string"
-   :uuid          #uuid "4fe5d828-6444-11e8-8222-720007e40350"
-   :number        1234
-   :symbol-w-meta (with-meta 'mysym {:foo :bar})
-   :boolean       true
-   :lambda        #(inc %)
-   :fn            juxt
-   :regex         #"^hi$"
-   :record        my-record-type
-   :datatype      my-data-type
-   :atom/number   (atom 1)
-   :brackets      [[[[[[]]]]]]
-   :map/with-meta (with-meta {:a :foo
-                              :b :bar}
-                    {:k1 "abcdefghijklmnop"
-                     :k2 "qrstuvwxyz"})})
+
+
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -403,157 +253,11 @@
 ;;        [e f g &  h]                             ["a" "b" "c" "d" "e"]]
 ;;       [a b c d e f g h])
   )
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; SMOKE TESTS WITH COMMENTARY END
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
-
-
-#?(:clj
-   (do 
-     #_(do
-         ;; DataTypes ------------------------------------------------------
-         (? "A def of deftype" (deftype MyType [a b]))
-         
-         (? "A deftype" MyType)
-         (def my-data-type (->MyType 2 3))
-         (? "Instance of deftype" my-data-type)
-
-
-         ;; RecordTypes ----------------------------------------------------
-         (defrecord MyRecordType [a b c d])
-         (? "A record type" MyRecordType)
-         (defrecord MySubRecordType [x y])
-         (def my-record-type (->MyRecordType 
-                              (->MySubRecordType "adfasdfasdfasdfasdf" "y")
-                              #_"asdfasdfasdfsafasdfadf"
-                              "xyxyxyxyxyxxyxxy"
-                              123456
-                              juxt))
-         (? "Instance of record type" MyRecordType)
-
-
-         ;; Multimethods ---------------------------------------------------
-         (defmulti different-behavior (fn [x] (:x-type x)))
-         (defmethod different-behavior :wtf
-           [x]
-           (str (:name x) " will have a specific behavior"))
-         (? "Multimethod" different-behavior)
-
-
-         ;; Dates ----------------------------------------------------------
-         (def my-date (java.util.Date.))
-         (? "A java date" my-date)
-
-
-         ;; Function -------------------------------------------------------
-         (defn xy [x y] (+ x y))
-         (? "2-arity function" xy)
-
-         (defn xy-variadic [x y & args] (+ x y))
-         (? "variadic function" xy-variadic)
-
-
-         ;; Collections ----------------------------------------------------
-         (? "anonymous function" (fn xy-variadic []))
-         (? "anonymous function sugared" #(inc %))
-         (? "vector"               [1 2 3])
-         (? "set"                  #{1 2 3})
-         (? "list"                 '(1 2 3))
-         (? "seq"                  (range 10))
-         (? "record"               my-record-type)
-         (? {:coll-limit 5 :label "truncation"} [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23])
-         (let [o {:coll-limit 5 :label "truncation with opts var"}]
-           (? o [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23]))
-         (? "colls-as-keys"        {[1 2]    "afjasljfalsjdalsfk" #{1 2 3} "afsdfasdfsdfasfas"})
-
-
-         ;; Abstractions ----------------------------------------------------
-         (? "Atom" {:atom (atom 1)})
-
-
-         ;; Java Number Types -----------------------------------------------
-         (? "##NaN" ##NaN)
-         (? "##Inf" ##Inf)
-         (? "##-Inf" ##-Inf)
-         (? "1/3" 1/3)
-         (? "byte" (byte 0))
-         (? "short" (short 3))
-         (? "double" (double 23.44))
-         (? "decimal" 1M)
-         (? "int" 1)
-         (? "float" (float 1.50))
-         (? "char" (char 97))
-         (? "java.math.BigInteger" (java.math.BigInteger. "171"))
-         (? {:label      "Basic samples"
-             :coll-limit 15
-            ;;  :theme      "Alabaster Light"
-             :theme      themes/alabaster-light
-             :find       {:pred #(= 1234 %)}}
-            basic-samples-cljc)
-
-
-
-
-         ;; Custom printing -- ! Leave this off until feature re-implemented
-        
-        ;;  (? {:custom-printers {:vector {:pred        (fn [x] (= x [765 233 444 21]))
-        ;;                                 :f           (fn [x] (into #{} x))
-        ;;                                 :badge-text  " Set💩 "
-        ;;                                 :badge-style {:color            "#000"
-        ;;                                               :background-color "lime"
-        ;;                                               :border-radius    "999px"
-        ;;                                               :text-shadow      "none"
-        ;;                                               :font-style       "normal"}}}
-        ;;      }
-        ;;     [765 233 444 21])
-
-         ;; Metadata
-         (?
-            {:label             "Nested metadata, :block positioning"
-              :metadata-position :block}
-            (with-meta 
-                    {(with-meta (symbol :a)
-                        {:abc "bar"
-                        :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})
-                      (with-meta (symbol "foo")
-                        {:abc "bar"
-                        :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})
-                      :b {:foo 'bar}}
-                    {:a                (with-meta (symbol "foo")
-                                          {:abc  (with-meta (symbol "bar") {:a 1 #_(with-meta (symbol "foo") {:a 1})})
-                                          :xyz  "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-                                          ;;  "hi there everyone" #uuid "97bda55b-6175-4c39-9e04-7c0205c709dc"
-                                          })
-                      ;; :xyz              "bar" 
-                      ;; "hi there everyone" #uuid "97bda55b-6175-4c39-9e04-7c0205c709dc"
-                      }))
-
-         
-         (?
-          "Nested metadata, :inline positioning"
-          (with-meta 
-            {(with-meta (symbol :a)
-               {:abc "bar"
-                :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})
-             (with-meta (symbol "foo")
-               {:abc "bar"
-                :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})
-             :b {:foo 'bar}}
-            {:a                (with-meta (symbol "foo")
-                                 {:abc  (with-meta (symbol "bar") {:a 1 #_(with-meta (symbol "foo") {:a 1})})
-                                  :xyz  "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-                                          ;;  "hi there everyone" #uuid "97bda55b-6175-4c39-9e04-7c0205c709dc"
-                                  })
-                      ;; :xyz              "bar" 
-                      ;; "hi there everyone" #uuid "97bda55b-6175-4c39-9e04-7c0205c709dc"
-             }))
-         )))
-  
+ ;; -------------------------------------------------------------
+ ;; TODO - Use the co fn to add some commentary to samples below.
+ ;; -------------------------------------------------------------
 
  ;; Testing all the stock themes cljc
  #_(do
@@ -659,162 +363,15 @@
                        :printer {:function-args {:color "#bb8f44"}}}}}
    {:string "string"})
 
-  (? {:label "Alabaster Dark"
-      :theme "Alabaster Dark"}
-     {:string "string"})
 
-  (? {:theme "Alabaster Light"}
-     {:string "string"})
-
-  #?(:clj
-     (? {:label "java.util.ArrayList" :coll-limit 10} (java.util.ArrayList. [1 2 3 4 5 6 7 8 9 10 11 12 13]))))  
+  )  
 
 
-;; Random js data structure tests
-
-;; (let [
-;;         ;; itInt8Array  (new js/Int8Array
-;;         ;;                   #js[1 2 3 4 5 6 7 8 9])
-;;         ;; jsarray  #js[1 2 3 4 5 6 7 8 9]
-;;         itmap (new js/Map
-;;                    #js[#js["a", 1],
-;;                        #js["b", 2]
-;;                        #js["c", 3]
-;;                        #js["d", 4]])
-;;         ;; it #_[1 2 3 [1 2 3 [1 2 3]]]
-;;         ;; {:a           [1 3 8 7 5 9 3 99 88]
-;;         ;;  :bee         {:a 'foo
-;;         ;;                :b {:a 'foo
-;;         ;;                    :b [:wtf]}}
-;;         ;;  :b           "hello, world"
-;;         ;;  :c           (new js/Date) 
-;;         ;;  :d           #js {:a "bar"
-;;         ;;                    :b "bar"}
-;;         ;;  :jsmap       (new js/Map
-;;         ;;                    #js[#js["a", 1],
-;;         ;;                        #js["b", 2]
-;;         ;;                        #js["c", 3]
-;;         ;;                        #js["d", 4]])
-;;         ;;  :itInt8Array (new js/Int8Array
-;;         ;;                    #js[1 2 3 4 5 6 7 8 9])
-;;         ;;  :e           #uuid "97bda55b-6175-4c39-9e04-7c0205c709dc"
-;;         ;;  }
-;;         ;; pw (truncate 0 it)
-;;         ts (with-meta
-;;              {"asfasdfasdfasdfasdfasdfasdfasdfasfadf"                          12
-;;               :foo                                                           (with-meta #{:a 1}
-;;                                                                                {:foo  "on a sev blah blah"
-;;                                                                                 :ffoo "adfadsfadsfasfdasdfasdfassasfsdfasd"
-;;                                                                                 :baz  "adfadsfadsfasfdasdfasdfassasdfadsfasdf"}) 
-;;               #uuid "97bda55b-6175-4c39-9e04-7c0205c709dc" itmap
-;;               ;; :itmap itmap
-;;               }
-;;              {:foo  "adfadsfadsfasfdasdfasdfas"
-;;               :ffoo "adfadsfadsfasfdasdfasdfas"
-;;               :baz  [123 9898 8989898 89898989 988989]})
-;;         ;; tss {:foo "bar"}
-;;         ]
-
-;;     (? basic-samples-cljc)
-
-;;     #_(? {:theme monokai-light}
-;;      {:a (with-meta (symbol "foo")
-;;            {:abc "bar"
-;;             :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})
-;;       :b 1})
-
-;;     #_(? {:theme degas-light} (with-meta 
-;;                                 {(with-meta (symbol :a)
-;;                                    {:abc "bar"
-;;                                     :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"}) (with-meta (symbol "foo")
-;;                                                                                              {:abc "bar"
-;;                                                                                               :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})
-;;                                  :b                                                                                         2}
-;;                                 {:a (with-meta (symbol "foo")
-;;                                       {:abc (with-meta (symbol "bar") {:a   (with-meta (symbol "a")
-;;                                                                               {:abc (with-meta (symbol "a")
-;;                                                                                       {:abc (with-meta (symbol "a")
-;;                                                                                               {:abc "abc"
-;;                                                                                                :xyz "xyz"})
-;;                                                                                        :xyz "xyz"})
-;;                                                                                :xyz "xyz"})
-;;                                                                        :xyz "abcdefghijklmnopqrstuv"})
-;;                                        :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})}))
-
-;;     ;; (? {[1 2] "afjasljfalsjdalsfk" #{1 2 3} "afsdfasdfsdfasfas"})
-
-;;     #_(? {:a         1234
-;;         :abc       3333
-;;         :goldenrod "97bda55b-6175-4c39-9e04-7c0205c709dc"})
-
-;;     #_(? {:theme alabaster-lightx}
-;;        {:a                 "foo"
-;;         :xyz               {:a         1234
-;;                             :abc       3333
-;;                             :goldenrod "97bda55b-6175-4c39-9e04-7c0205c709dc"}
-;;         2222               :wtf
-;;         :hi-there-everyone #uuid "97bda55b-6175-4c39-9e04-7c0205c709dc"})
-
-;;     #_(? {:theme             alabaster-lightx
-;;         :metadata-position :inline}
-;;        (with-meta 
-;;          {(with-meta (symbol :a)
-;;             {:abc "bar"
-;;              :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})
-;;           (with-meta (symbol "foo")
-;;             {:abc "bar"
-;;              :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})
-;;           :b "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-;;           :122222 5555555}
-;;          {:a                (with-meta (symbol "foo")
-;;                               {:abc  (with-meta (symbol "bar") {:a 1 #_(with-meta (symbol "foo") {:a 1})})
-;;                                :xyz  "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-;;                                ;;  "hi there everyone" #uuid "97bda55b-6175-4c39-9e04-7c0205c709dc"
-;;                                })
-;;           ;; :xyz              "bar" 
-;;           ;; "hi there everyone" #uuid "97bda55b-6175-4c39-9e04-7c0205c709dc"
-;;           }))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; SMOKE TESTS WITH COMMENTARY END
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
-;;     #_(?-- (with-meta [] #_(symbol "foo")
-;;          {:xyz "abcdefghijklmnopqrstuvwxyzzzzzzz"}
-;;          #_{:xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"}
-;;          ))
-;;     #_(? {:theme             alabaster-lightx
-;;         :metadata-position :inline}
-;;        (with-meta
-;;          [:b]
-;;          {:a                "foo"
-;;           :xyz              "bar" 
-;;           "hi there everyone" #uuid "97bda55b-6175-4c39-9e04-7c0205c709dc"})))
-
-(def basic-samples 
-  {:string   "string"
-   :uuid     #uuid "4fe5d828-6444-11e8-8222-720007e40350"
-   :number   1234
-   :boolean  true
-   :lambda    #(inc %)
-   :fn       juxt
-   :regex    #"^hi$"
-   :record   my-record-type
-   :range    (range 40)
-   :atom2    (atom my-record-type)
-   :atom1    (atom 1)
-   :brackets [[[[[[]]]]]]})
-
-(def basic-samples-array-map
-  (array-map
-   :string   "string"
-   :uuid     #uuid "4fe5d828-6444-11e8-8222-720007e40350"
-   :number   1234
-   :boolean  true
-   :lambda    #(inc %)
-   :fn       juxt
-   :regex    #"^hi$"
-   :record   my-record-type
-   :range    (range 40)
-   :atom2    (atom my-record-type)
-   :atom1    (atom 1)
-   :brackets [[[[[[]]]]]] ))
-
-basic-samples

--- a/visual_test/shadow-cljs.edn
+++ b/visual_test/shadow-cljs.edn
@@ -4,7 +4,7 @@
                 ;; Local Fireworks - uncomment if debugging Fireworks locally
                 "../src/"
                 ;; Local Lasertag - uncomment if debugging Lasertag locally
-                ;; "../../lasertag/src/"
+                "../../lasertag/src/"
                 ;; Local Bling - uncomment if debugging Bling locally
                 ;; "../../bling/src/"
                 ]

--- a/visual_test/shadow-cljs.edn
+++ b/visual_test/shadow-cljs.edn
@@ -2,7 +2,7 @@
 ;; shadow-cljs configuration
 {:source-paths ["src/"
                 ;; Local Fireworks - uncomment if debugging Fireworks locally
-                ;; "../src/"
+                "../src/"
                 ;; Local Lasertag - uncomment if debugging Lasertag locally
                 ;; "../../lasertag/src/"
                 ;; Local Bling - uncomment if debugging Bling locally

--- a/visual_test/shadow-cljs.edn
+++ b/visual_test/shadow-cljs.edn
@@ -2,14 +2,15 @@
 ;; shadow-cljs configuration
 {:source-paths ["src/"
                 ;; Local Fireworks - uncomment if debugging Fireworks locally
-                "../src/"
+                ;; "../src/"
                 ;; Local Lasertag - uncomment if debugging Lasertag locally
-                "../../lasertag/src/"
+                ;; "../../lasertag/src/"
                 ;; Local Bling - uncomment if debugging Bling locally
                 ;; "../../bling/src/"
+                ;; "../../bling/test/"
                 ]
  :dependencies [[io.github.paintparty/fireworks "0.10.4-SNAPSHOT"]
-                [io.github.paintparty/bling "0.4.0-SNAPSHOT"]
+                [io.github.paintparty/bling "0.4.2"]
                 [binaryage/devtools "1.0.6"]]
  :dev-http     {8020 "public"}
  :builds       {:app  {:target           :browser

--- a/visual_test/src/visual_testing/browser.cljs
+++ b/visual_test/src/visual_testing/browser.cljs
@@ -2,7 +2,7 @@
   (:require
    [fireworks.core :refer [? !? ?> !?>]]
    [visual-testing.macros :refer-macros [test-clj]]
-   [visual-testing.shared :refer [foo test-suite]]))
+   [visual-testing.shared :refer [test-suite]]))
 
 ;; start is called by init and after code reloading finishes
 (defn ^:dev/after-load start []
@@ -64,7 +64,8 @@
   (test-suite)
 
   ;; This will run same visual test suite in terminal where shadow is running
-  (println (test-clj)))
+  ;; Disable for now
+  #_(println (test-clj)))
 
 
 

--- a/visual_test/src/visual_testing/browser.cljs
+++ b/visual_test/src/visual_testing/browser.cljs
@@ -55,17 +55,20 @@
   ;;      :coll/vector [:a :b :c [1 2 [:x :y]]]
   ;;      :coll/set    #{:a :b :c}
   ;;      :coll/record (->Foo "a" "b")})
-
+  
   ;; TESTING CODE FOR THEMES & FEATURES
-
+  
   (js/console.clear)
+
+  ;; (println (test-clj))
 
   ;; This will run test suite of cljc calls to fireworks.core/? in browser dev-console 
   (test-suite)
 
+
   ;; This will run same visual test suite in terminal where shadow is running
   ;; Disable for now
-  #_(println (test-clj)))
+  #_(test-clj))
 
 
 

--- a/visual_test/src/visual_testing/macros.clj
+++ b/visual_test/src/visual_testing/macros.clj
@@ -3,6 +3,4 @@
             [visual-testing.shared :refer [test-suite]]))
 
 (defmacro test-clj []
-  (test-suite)
-  ;; TODO add clj-specific test
-  nil)
+  (test-suite))

--- a/visual_test/src/visual_testing/shared.cljc
+++ b/visual_test/src/visual_testing/shared.cljc
@@ -1,442 +1,59 @@
 (ns visual-testing.shared
   (:require [fireworks.config]
             [fireworks.themes]
-            [fireworks.sample :as sample :refer [show-everything]]
+            [fireworks.sample :as sample :refer []]
             [bling.sample]
-            [clojure.string :as string]
             [lasertag.core :refer [tag-map]]
-            [cljs.js]
             [fireworks.core :refer [? !? ?> !?> pprint]]))
 
-(defrecord Foo [a b])
-(def record-sample (->Foo 1 2))
-(deftype MyType [a b])
-(def my-data-type (->MyType 2 3))
-(defrecord MyRecordType [a b])
-(def my-record-type (->MyRecordType "a" "b"))
-(defmulti different-behavior (fn [x] (:x-type x)))
-(defmethod different-behavior :wolf
-  [x]
-  (str (:name x) " will have a specific behavior"))
-(defn xy [x y] (+ x y))
-(defn xyv ([x y] (+ x y)) ([x y v] (+ x y v)))
-(defn xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz [x y] (+ x y))
+(def everything sample/array-map-of-everything-cljc)
 
-(def foo
-  {:string        "string"
-   :uuid          #uuid "4fe5d828-6444-11e8-8222-720007e40350"
-   :number        1234
-  ;;  :symbol          (with-meta 'mysym {:foo :bar})
-   :symbol        {:foo :bar}
-   :boolean       true
-   :lambda         #(inc %)
-   :fn            juxt
-   :regex         #"^hi$"
-   :record        record-sample
-   :atom/number   (atom 1)
-   :brackets      [[[[[[]]]]]]
-   :map/with-meta (with-meta {:a :foo :b :bar}
-                    {:k1 "abcdefghijklmnop" 
-                     :k2 "qrstuvwxyz" })
-  ;;  :map/with-meta (with-meta {:a :foo
-  ;;                               :b 2}
-  ;;                     {:a (with-meta (symbol "foo")
-  ;;                           {:abc (symbol "foobarbaz")
-  ;;                            :xyz "abcdefghijklmnop"})})
-   })
-
-
-
-(def basic-samples-cljc 
-  (array-map
-   :string             "string"
-   :uuid               #uuid "4fe5d828-6444-11e8-8222-720007e40350"
-   :number             1234
-   :symbol             (with-meta 'mysym {:foo :bar})
-   :boolean            true
-   :symbol2            (with-meta 'mysym
-                         {:foo ["afasdfasf"
-                                "afasdfasf"
-                                {:a "foo"
-                                 :b [1 2 [1 2 3 4]]}
-                                "afasdfasf"
-                                "afasdfasf"]
-
-                          :bar "fooz"})
-   :regex              #"^hi$"
-   :lambda              #(inc %)
-   :fn                 juxt
-   :fn-multi-arity     xyv
-   :fn-long-name       xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz
-   :multimethod        different-behavior
-   :record             record-sample
-   :datatype           my-data-type
-   :atom/record        (atom record-sample)
-   :atom/number        (atom 1)
-   :brackets           [[[[[[]]]]]]
-   :map/nested-meta    (with-meta 
-                         {(with-meta (symbol :a)
-                            {:abc "bar"
-                             :xyz "abc"}) (with-meta (symbol "foo")
-                                            {:abc "bar"
-                                             :xyz "abc"})
-                          :b                                               2}
-                         {:a (with-meta (symbol "foo")
-                               {:abc (symbol "bar")
-                                :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})})
-   :map/single-line    {:a 1
-                        :b 2
-                        :c "three"}
-   :map/multi-line     {:abc      "bar"
-                        "asdfasdfa" "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-                        [:a :b]   123444}
-   :vector/single-line [1 :2 "three"]
-   :vector/multi-line  ["abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-                        :22222
-                        3333333]
-   :list/single-line   '(1 :2 "three")
-   :list/multi-line    '("abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-                         :22222
-                         3333333)
-   :set/single-line    #{1 :2 "three"}
-   :set/multi-line     #{"abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-                         :22222
-                         3333333}))
-
-#_(defn test-suite []
-  #?(:cljs
-     (do
-       #_(? #_{:label                      "my-label"
-               :enable-terminal-truecolor? true
-               :enable-terminal-italics?   true
-               :bracket-contrast           "high"
-               :theme                      "Alabaster Light"}
-          #js [1 2 3])
-
-       #_(? [1 (new js/Int8Array #js[1 2 3])])
-
-       #_(? (lasertag.core/tag #js {:a 1
-                                    :b 2}))
-       #_(? [1 #js [1 2 3 4 5]])
-
-       #_(? [1 #js ["a" #js [1 2 3] "b"]])
-
-       #_(? [1 (new js/Set #js[1])])
-       #_(? [1 #js {:a 1
-                    :b 2}])))
-
-  (? {:theme "Alabaster Light"
-      :label "basic-samples-cljc"}
-     basic-samples-cljc)
-
-  (? foo)
-
-  (? :default foo)
-
-  (? {:theme "Alabaster Light"
-      :label "Alabaster Light"} foo)
-  (? {:theme "Monokai Light"
-      :label "Monokai Light"} foo)
-  (? {:theme "Alabaster Dark"
-      :label "Alabaster Dark"} foo)
-  (? {:theme "Monokai Dark"
-      :label "Monokai Dark"} foo)
-  (? {:theme "Universal Neutral"
-      :label "Universal Neutral"} foo)
-
-
-;; OFF-start
-;; (? {:theme "Zenburn Light" :label "Zenburn Light"} foo)
-;; (? {:theme "Solarized Light" :label "Solarized Light"} foo)
-;; (? {:theme "Degas Light" :label "Degas Light"} foo)
-;; (? {:theme "Neutral Light" :label "Neutral Light"} foo)
-  
-;; (? {:theme "Alabaster Dark" :label "Alabaster Dark"} foo)
-;; (? {:theme "Zenburn Dark" :label "Zenburn Dark"} foo)
-;; (? {:theme "Monokai Dark" :label "Monokai Dark"} foo)
-;; (? {:theme "Solarized Dark" :label "Solarized Dark"} foo)
-;; (? {:theme "Degas Dark" :label "Degas Dark"} foo)
-;; (? {:theme "Neutral Dark" :label "Neutral Dark"} foo)
-;; OFF-end
-  
-  (println "\n:label-length-limit of 10")
-  (? {:label-length-limit 10} (str "1234567890" "abcdefghijklmnopqrstuvwxyz"))
-
-  (println "\n:label-length-limit of 50")
-  (? {:label-length-limit 50} (str "1234567890"
-                                   "abcdefghijklmnopqrstuvwxyz"
-                                   "ABCDEFGHIJKLMNOP"))
-
-  (println "\n:single-line-coll-length-limit of 10")
-  (? {:single-line-coll-length-limit 10} (range 4))
-
-  (println "\n:single-line-coll-length-limit of 10")
-  (? {:single-line-coll-length-limit 10} (range 5))
-
-  (println "\n:single-line-coll-length-limit of 50")
-  (? {:single-line-coll-length-limit 50} (range 19))
-
-  (println "\n:single-line-coll-length-limit of 50")
-  (? {:single-line-coll-length-limit 50} (range 20))
-
-  
-  (println "\n:Volatile, record")
-  (? {:label                      "my-label"
-      :enable-terminal-truecolor? true
-      :enable-terminal-italics?   true
-      :bracket-contrast           "high"}
-     (volatile! record-sample))
-
-  (println "\n:Transient Array")
-  (let [x (transient [1 2 3 4 5 6 7 8 9 0])]
-    (? {:coll-limit                 7
-        :label                      "my-label"
-        :enable-terminal-truecolor? true
-        :enable-terminal-italics?   true
-        :bracket-contrast           "high"}
-       x)
-    (conj! x 5)) 
-
-  (println "\n:Transient Map")
-  (let [x (transient {:a 1
-                      :b 2
-                      :c 3
-                      :d 4
-                      :e 5
-                      :f 6
-                      :g 7
-                      :h 8
-                      :i 9
-                      :j 10 })]
-    (? {:coll-limit 7} x)
-    (assoc! x :k 11))
-
-  (println "\n:Transient Set")
-  (let [x (transient #{1 2 3 4 5 6 7 8 9 0})]
-    (? {:label      "Transient Set"
-        :coll-limit 7} x)
-    (conj! x 11))
-
-  (println "\n:Array, :pp mode")
-  (? :pp (into-array '(1 2 3)))
-
-  nil)
-
-
-
-;; For trying stuff out
 (defn test-suite []
   #?(:cljs
-     (!? {:coll-limit 200}
-         (let [ks (keys lasertag.cljs-interop/js-built-ins-by-category)]
-           (reduce
-            (fn [acc [k v]]
-              (assoc acc
-                     k
-                     (apply array-map
-                            (reduce (fn [acc [jsf {:keys [sym
-                                                          demo
-                                                          args
-                                                          not-a-constructor?]}]]
-                                      (conj acc
-                                            sym
-                                            (if (and (not not-a-constructor?)
-                                                     demo)
-                                              (let [res (volatile! nil)]
-                                                (cljs.js/eval-str
-                                                 (cljs.js/empty-state)
-                                                 demo
-                                                 nil
-                                                 {:eval       cljs.js/js-eval    
-                                                  :source-map true
-                                                  :context    :expr}
-                                                 (fn [x]
-                                                   (vreset! res (:value x))))
-                                                @res)
-                                              ::no-demo
-                                              )))
-                                    []
-                                    v))))
-            {}
-            lasertag.cljs-interop/js-built-ins-by-category
-            #_(do 
-                (select-keys
-                 lasertag.cljs-interop/js-built-ins-by-category
-                 [
-                ;; "Fundamental"
-                ;; "objects"
-                ;; "Numbers and dates"
-                ;; "Value properties"
-                ;; "Control abstraction objects"
-                ;; "Error objects"
-                ;; "Text processing"
-                ;; "Function properties"
-                ;; "Keyed collections" 
-                ;; "Indexed collections"
-                ;; "Structured data"
-                ;; "Internationalization"
-                  "Managing memory"
-                  "Reflection"
-                  ]))))
+     ;; Move this interop demo code into fireworks.sample
+     (do #_(? {:coll-limit 200
+             :label      "ClojureScript interop types"}
+            sample/interop-types)
+         
+         (? {:coll-limit 200
+             :label      "Clojure(Script) values"}
+            everything)
 
-         #_(doseq [[k v] lasertag.cljs-interop/js-built-in-objects-by-object-map]
-             (? :result k)
-             (? :result v)
-             ))
-     :clj
-     ())
+         (!? {:label      "Clojure(Script) multiline formatting"}
+            sample/array-map-of-multiline-formatting-cljc)))
+
+  #_(do 
+    (? {:theme "Alabaster Light"
+        :label "Alabaster Light"} everything)
+    (? {:theme "Monokai Light"
+        :label "Monokai Light"} everything)
+    (? {:theme "Alabaster Dark"
+        :label "Alabaster Dark"} everything)
+    (? {:theme "Monokai Dark"
+        :label "Monokai Dark"} everything)
+    (? {:theme "Universal Neutral"
+        :label "Universal Neutral"} everything))
   
+  #_(do 
+    (println "\n:label-length-limit of 10")
+    (? {:label-length-limit 10} (str "1234567890" "abcdefghijklmnopqrstuvwxyz"))
 
-  #_(? {:print-with prn} 
-       (-> (? :data {:a 1})
-           :formatted
-           :string))
+    (println "\n:label-length-limit of 50")
+    (? {:label-length-limit 50} (str "1234567890"
+                                     "abcdefghijklmnopqrstuvwxyz"
+                                     "ABCDEFGHIJKLMNOP"))
 
-  #_(? {:coll-limit 100
-        :theme      "Alabaster Light"
-        :label      "Clojure(Script) Values"}
-       sample/array-map-of-everything-cljc) 
+    (println "\n:single-line-coll-length-limit of 10")
+    (? {:single-line-coll-length-limit 10} (range 4))
 
-  #_(? {:coll-limit 100
-        :theme      "Alabaster Light"
-        :label      "Clojure(Script) Values"}
-       sample/vec-of-everything-cljc) 
+    (println "\n:single-line-coll-length-limit of 10")
+    (? {:single-line-coll-length-limit 10} (range 5))
 
-  #_(? {:coll-limit 100
-        :theme      "Alabaster Light"
-        :label      "Clojure(Script) Values"}
-       sample/vec-of-everything-cljc-with-extras) 
+    (println "\n:single-line-coll-length-limit of 50")
+    (? {:single-line-coll-length-limit 50} (range 19))
 
-  (println (? :data "foo"))
-  ;; (? "foo")
-
-  #_(? {:coll-limit 100
-        :label      #?(:cljs "ClojureScript Values" :clj "JVM Clojure Values")}
-       (show-everything [:number-types
-                         :interop-collection-types] 
-                        {:as-vec?     false
-                    ;;  :show-extras?         true
-                    ;;  :show-extras-as-meta? true
-                         :extras-keys [#_:tag
-                                       #_:call
-                                       :all-tags]}))
-  #_(? :pp (into-array '(1 2 3)))
-  #_(? {:label                        "my-label"
-        :enable-terminal-truecolor?   true
-        :enable-terminal-italics?     true
-        :bracket-contrast             "high"
-        :custom-printers              {}
-        :coll-limit                   20
-        :non-coll-length-limit        (-> fireworks.config/options
-                                          :non-coll-length-limit
-                                          :default)
-        :display-namespaces?          (-> fireworks.config/options
-                                          :display-namespaces?
-                                          :default)
-        :metadata-position            (-> fireworks.config/options
-                                          :metadata-position
-                                          :default)
-        :metadata-print-level         (-> fireworks.config/options
-                                          :metadata-print-level
-                                          :default)
-        :non-coll-mapkey-length-limit (-> fireworks.config/options
-                                          :non-coll-mapkey-length-limit
-                                          :default)} basic-samples-cljc)
-  ;; (println "v")
-  ;; (pprint (? :data (volatile! record-sample)))
-  
-  #_#?(:cljs
-       (do 
-      ;;  (println "atom")
-      ;;  (pprint (:formatted (? :data (atom record-sample))))
-      ;;  (? (atom record-sample))
-         
-      ;;  (println "\n\n")
-         
-      ;;  (println "Volatile")
-         (pprint (:formatted (? :data 
-                                {:label                      "my-label"
-                                 :enable-terminal-truecolor? true
-                                 :enable-terminal-italics?   true
-                                 :bracket-contrast           "high"}
-                                (volatile! record-sample))))
-      ;;  (? (volatile! record-sample))
-      ;;  (? (lasertag.core/js-object-instance (transient [1 2 3 4])))
-         #_(let [x (transient [1 2 3 4 5 6 7 8 9 0])]
-             (? {:coll-limit                 7
-                 :label                      "my-label"
-                 :enable-terminal-truecolor? true
-                 :enable-terminal-italics?   true
-                 :bracket-contrast           "high"}
-                x)
-             #_(pprint (? :data {:coll-limit                 7
-                                 :label                      "my-label"
-                                 :enable-terminal-truecolor? true
-                                 :enable-terminal-italics?   true
-                                 :bracket-contrast           "high"}
-                          x))
-             (conj! x 5))
-         
-      ;;  (let [x (transient #{1 2 3 4 5 6 7 8 9 0})]
-      ;;    (? "Transient set" {:coll-limit 7} x)
-      ;;    (conj! x 11))
-         
-         #_(? {})
-
-         #_(let [x (transient {:a 1
-                               :b 2
-                               :c 3
-                               :d 4
-                               :e 5
-                               :f 6
-                               :g 7
-                               :h 8
-                               :i 9
-                               :j 10 })]
-             (? {:coll-limit 7} x)
-             (assoc! x :k 11))
-         
-         #_(? (volatile! record-sample))
-
-         #_(let [x (transient #{:a 1
-                                :b 2
-                                :c 3
-                                :d 4
-                                :e 5
-                                :f 6
-                                :g 7
-                                :h 8
-                                :i 9
-                                :j 10 })]
-             (? {:coll-limit 7} x)
-             (conj! x 11))
-         
-         #_(? (transient {:a 1
-                          :b 2
-                          :c 3
-                          :d 4
-                          :e 5
-                          :f 6
-                          :g 7
-                          :h 8
-                          :i 9
-                          :j 10}))
-      ;;  (? (lasertag.core/tag-map 1))
-      ;;  (js/console.log lasertag.cljs-interop/js-built-in-objects-by-object-map)
-      ;;  (js/console.log lasertag.cljs-interop/js-built-ins-by-category)
-         
-      ;;  (? (lasertag.core/js-object-instance 1))
-         
-      ;;  (? (transient [1 2 3 4]))
-      ;;  (? (type (transient #{1 2 3 4})))
-      ;;  (? (type (transient {1 2 3 4})))
-      ;;  (? (type (transient {1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 191 20 21 22})))
-      ;;  (? (type (transient {1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 191 20 21 22})))
-         
-      ;;  (? (atom record-sample))
-         )
-       :clj
-       nil)
+    (println "\n:single-line-coll-length-limit of 50")
+    (? {:single-line-coll-length-limit 50} (range 20)))
 
   nil)
 

--- a/visual_test/src/visual_testing/shared.cljc
+++ b/visual_test/src/visual_testing/shared.cljc
@@ -14,12 +14,12 @@
      (do #_(? {:coll-limit 200
              :label      "ClojureScript interop types"}
             sample/interop-types)
-         
+
          (? {:coll-limit 200
              :label      "Clojure(Script) values"}
             everything)
 
-         (!? {:label      "Clojure(Script) multiline formatting"}
+         (? {:label      "Clojure(Script) multiline formatting"}
             sample/array-map-of-multiline-formatting-cljc)))
 
   #_(do 
@@ -56,5 +56,5 @@
     (? {:single-line-coll-length-limit 50} (range 20)))
 
   ;; Test bling
-  (bling.sample/sample)
+  #_(bling.sample/sample)
   nil)

--- a/visual_test/src/visual_testing/shared.cljc
+++ b/visual_test/src/visual_testing/shared.cljc
@@ -7,8 +7,18 @@
             [fireworks.core :refer [? pprint]]))
 
 (defrecord Foo [a b])
-
 (def record-sample (->Foo 1 2))
+(deftype MyType [a b])
+(def my-data-type (->MyType 2 3))
+(defrecord MyRecordType [a b])
+(def my-record-type (->MyRecordType "a" "b"))
+(defmulti different-behavior (fn [x] (:x-type x)))
+(defmethod different-behavior :wolf
+  [x]
+  (str (:name x) " will have a specific behavior"))
+(defn xy [x y] (+ x y))
+(defn xyv ([x y] (+ x y)) ([x y v] (+ x y v)))
+(defn xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz [x y] (+ x y))
 
 (def foo
   {:string        "string"
@@ -33,52 +43,63 @@
   ;;                            :xyz "abcdefghijklmnop"})})
    })
 
-(def basic-samples-cljc 
-  {:abcdefg {:string             "string"
-             :uuid               #uuid "4fe5d828-6444-11e8-8222-720007e40350"
-             :number             1234
-             :symbol             (with-meta 'mysym {:foo :bar})
-             :symbol2            (with-meta 'mysym
-                                   {:foo ["afasdfasf"
-                                          "afasdfasf"
-                                          {:a "foo"
-                                           :b [1 2 [1 2 3 4]]}
-                                          "afasdfasf"
-                                          "afasdfasf"]
 
-                                    :bar "fooz"})
-             :boolean            true
-             :lambda              #(inc %)
-             :fn                 juxt
-             :regex              #"^hi$"
-             :record             record-sample
-             :atom/record        (atom record-sample)
-             :atom/number        (atom 1)
-             :brackets           [[[[[[]]]]]]
-             :map/nested-meta    (with-meta 
-                                   {(with-meta (symbol :a)
-                                      {:abc "bar"
-                                       :xyz "abc"}) (with-meta (symbol "foo")
-                                                      {:abc "bar"
-                                                       :xyz "abc"})
-                                    :b                                               2}
-                                   {:a (with-meta (symbol "foo")
-                                         {:abc (symbol "bar")
-                                          :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})})
-             :map/single-line    {:a 1
-                                  :b 2
-                                  :c "three"}
-             :map/multi-line     {:abc      "bar"
-                                  "asdfasdfa" "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-                                  [:a :b]   123444}
-             :vector/single-line [1 :2 "three"]
-             :vector/multi-line  ["abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-                                  :22222
-                                  3333333]
-             :set/single-line    #{1 :2 "three"}
-             :set/multi-line     #{"abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
-                                   :22222
-                                   3333333}}})
+
+(def basic-samples-cljc 
+  (array-map
+   :string             "string"
+   :uuid               #uuid "4fe5d828-6444-11e8-8222-720007e40350"
+   :number             1234
+   :symbol             (with-meta 'mysym {:foo :bar})
+   :boolean            true
+   :symbol2            (with-meta 'mysym
+                         {:foo ["afasdfasf"
+                                "afasdfasf"
+                                {:a "foo"
+                                 :b [1 2 [1 2 3 4]]}
+                                "afasdfasf"
+                                "afasdfasf"]
+
+                          :bar "fooz"})
+   :regex              #"^hi$"
+   :lambda              #(inc %)
+   :fn                 juxt
+   :fn-multi-arity     xyv
+   :fn-long-name       xyasldfasldkfaslkjfzzzzzzzzzzzzzzzzzzz
+   :multimethod        different-behavior
+   :record             record-sample
+   :datatype           my-data-type
+   :atom/record        (atom record-sample)
+   :atom/number        (atom 1)
+   :brackets           [[[[[[]]]]]]
+   :map/nested-meta    (with-meta 
+                         {(with-meta (symbol :a)
+                            {:abc "bar"
+                             :xyz "abc"}) (with-meta (symbol "foo")
+                                            {:abc "bar"
+                                             :xyz "abc"})
+                          :b                                               2}
+                         {:a (with-meta (symbol "foo")
+                               {:abc (symbol "bar")
+                                :xyz "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"})})
+   :map/single-line    {:a 1
+                        :b 2
+                        :c "three"}
+   :map/multi-line     {:abc      "bar"
+                        "asdfasdfa" "abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
+                        [:a :b]   123444}
+   :vector/single-line [1 :2 "three"]
+   :vector/multi-line  ["abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
+                        :22222
+                        3333333]
+   :list/single-line   '(1 :2 "three")
+   :list/multi-line    '("abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
+                         :22222
+                         3333333)
+   :set/single-line    #{1 :2 "three"}
+   :set/multi-line     #{"abcdefghijklmnopqrstuvwxyzzzzzzzzzzzzzzzzzzzz"
+                         :22222
+                         3333333}))
 
 #_(defn test-suite []
   #?(:cljs

--- a/visual_test/src/visual_testing/shared.cljc
+++ b/visual_test/src/visual_testing/shared.cljc
@@ -55,8 +55,6 @@
     (println "\n:single-line-coll-length-limit of 50")
     (? {:single-line-coll-length-limit 50} (range 20)))
 
+  ;; Test bling
+  (bling.sample/sample)
   nil)
-
-;; For Bling
-#_(defn test-suite []
- (bling.sample/sample))


### PR DESCRIPTION
- Closes #47
- Adds `fireworks.sample` namespace as single source of truth for examples and data for testing.
- Bumps Lasertag and Bling deps